### PR TITLE
Return fallback from analyzeWebsite on failure

### DIFF
--- a/tests/psi.test.js
+++ b/tests/psi.test.js
@@ -16,4 +16,13 @@ assert.strictEqual(result.coreWebVitals.cls, 0.01);
 assert.strictEqual(result.performanceScore, 0.9);
 assert.strictEqual(result.seoScore, 0.93);
 assert.strictEqual(result.readabilityScore, 0.88);
+
+async function failFetch(_url) {
+  return { ok: false, status: 500 };
+}
+
+const fallback = await fetchPSIData('https://bad.example', failFetch);
+assert.strictEqual(fallback.performanceScore, 0);
+assert.strictEqual(fallback.coreWebVitals.lcp, 0);
 console.log('psi test passed');
+


### PR DESCRIPTION
## Summary
- return fallback analysis record instead of rethrowing on failure
- handle fallback object in API handler instead of throwing
- verify PSI helper returns default values when fetch fails

## Testing
- `npm run test`
- `npx tsc -p tsconfig.json --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_6841ac2d60d4832b93d1ddce2446567b