### PR TITLE
Update AnalysisResponse imports

### DIFF
--- a/src/components/dashboard/ComplianceTab.tsx
+++ b/src/components/dashboard/ComplianceTab.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Box, Typography, Grid, Card, CardContent, Alert, CircularProgress, Chip } from '@mui/material';
-import { AnalysisResponse } from '../../hooks/useAnalysisApi';
+import type { AnalysisResponse } from '@/types/analysis';
 import { dashIfEmpty } from '../../lib/ui';
 
 interface ComplianceTabProps {

--- a/src/components/dashboard/OverviewTab.tsx
+++ b/src/components/dashboard/OverviewTab.tsx
@@ -2,7 +2,7 @@
 import React from 'react';
 import { Box, Typography, Grid, Card, CardContent, CircularProgress, Alert } from '@mui/material';
 import { TrendingUp, Users, Clock, Star } from 'lucide-react';
-import { AnalysisResponse } from '../../hooks/useAnalysisApi';
+import type { AnalysisResponse } from '@/types/analysis';
 
 interface OverviewTabProps {
   data: AnalysisResponse | null;

--- a/src/components/dashboard/PerformanceTab.tsx
+++ b/src/components/dashboard/PerformanceTab.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import { Box, Typography, Grid, Card, CardContent, LinearProgress, CircularProgress, Alert } from '@mui/material';
 import { ChartContainer, ChartTooltip, ChartTooltipContent } from '../ui/chart';
 import { BarChart, Bar, XAxis, YAxis, ResponsiveContainer } from 'recharts';
-import { AnalysisResponse } from '../../hooks/useAnalysisApi';
+import type { AnalysisResponse } from '@/types/analysis';
 
 interface PerformanceTabProps {
   data: AnalysisResponse | null;

--- a/src/components/dashboard/SEOAnalysisTab.tsx
+++ b/src/components/dashboard/SEOAnalysisTab.tsx
@@ -2,7 +2,7 @@
 import React from 'react';
 import { Box, Typography, Grid, Card, CardContent, Chip, CircularProgress, Alert } from '@mui/material';
 import { CheckCircle, AlertCircle, XCircle } from 'lucide-react';
-import { AnalysisResponse } from '../../hooks/useAnalysisApi';
+import type { AnalysisResponse } from '@/types/analysis';
 
 interface SEOAnalysisTabProps {
   data: AnalysisResponse | null;

--- a/src/components/dashboard/TechTab.tsx
+++ b/src/components/dashboard/TechTab.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { Box, Typography, Grid, Card, CardContent, Chip, CircularProgress, Alert } from '@mui/material';
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '../ui/table';
 import { Shield, Globe, Server, Database, Code, Layers, Zap, Activity, BarChart } from 'lucide-react';
-import { AnalysisResponse } from '../../hooks/useAnalysisApi';
+import type { AnalysisResponse } from '@/types/analysis';
 interface TechTabProps {
   data: AnalysisResponse | null;
   loading: boolean;

--- a/src/components/dashboard/UIAnalysisTab.tsx
+++ b/src/components/dashboard/UIAnalysisTab.tsx
@@ -1,7 +1,7 @@
 
 import React from 'react';
 import { Box, Typography, Grid, CircularProgress, Alert } from '@mui/material';
-import { AnalysisResponse } from '../../hooks/useAnalysisApi';
+import type { AnalysisResponse } from '@/types/analysis';
 import ColorExtractionCard from './ui-analysis/ColorExtractionCard';
 import FontAnalysisCard from './ui-analysis/FontAnalysisCard';
 import ImageAnalysisCard from './ui-analysis/ImageAnalysisCard';

--- a/src/components/dashboard/ui-analysis/ColorExtractionCard.tsx
+++ b/src/components/dashboard/ui-analysis/ColorExtractionCard.tsx
@@ -2,7 +2,7 @@
 import React from 'react';
 import { Box, Typography, Card, CardContent } from '@mui/material';
 import { Palette } from 'lucide-react';
-import { AnalysisResponse } from '../../../hooks/useAnalysisApi';
+import type { AnalysisResponse } from '@/types/analysis';
 
 interface ColorExtractionCardProps {
   colors: AnalysisResponse['data']['ui']['colors'];

--- a/src/components/dashboard/ui-analysis/ContrastWarningsCard.tsx
+++ b/src/components/dashboard/ui-analysis/ContrastWarningsCard.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Box, Typography, Card, CardContent } from '@mui/material';
 import { AlertTriangle } from 'lucide-react';
-import { AnalysisResponse } from '../../../hooks/useAnalysisApi';
+import type { AnalysisResponse } from '@/types/analysis';
 
 interface ContrastWarningsCardProps {
   issues: AnalysisResponse['data']['ui']['contrastIssues'];

--- a/src/components/dashboard/ui-analysis/FontAnalysisCard.tsx
+++ b/src/components/dashboard/ui-analysis/FontAnalysisCard.tsx
@@ -2,7 +2,7 @@
 import React from 'react';
 import { Box, Typography, Card, CardContent, Chip } from '@mui/material';
 import { Type } from 'lucide-react';
-import { AnalysisResponse } from '../../../hooks/useAnalysisApi';
+import type { AnalysisResponse } from '@/types/analysis';
 
 interface FontAnalysisCardProps {
   fonts: AnalysisResponse['data']['ui']['fonts'];

--- a/src/components/dashboard/ui-analysis/ImageAnalysisCard.tsx
+++ b/src/components/dashboard/ui-analysis/ImageAnalysisCard.tsx
@@ -2,7 +2,7 @@
 import React, { useState } from 'react';
 import { Box, Typography, Grid, Card, CardContent } from '@mui/material';
 import { Image } from 'lucide-react';
-import { AnalysisResponse } from '../../../hooks/useAnalysisApi';
+import type { AnalysisResponse } from '@/types/analysis';
 import ExpandableImageBox from './ExpandableImageBox';
 
 interface ImageAnalysisCardProps {


### PR DESCRIPTION
## Summary
- import `AnalysisResponse` type from `@/types/analysis`
- update dashboard component imports

## Testing
- `npm ci` *(fails: 403 Forbidden)*
- `npx tsc -b tsconfig.json` *(fails: missing modules)*

------
https://chatgpt.com/codex/tasks/task_e_6841ac2c73e0832bb4bfd8f4db948d4c