### PR TITLE
Update tsconfig.test to exclude old analyze function

### DIFF
--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -15,7 +15,6 @@
     "src/lib/export.ts",
     "src/types/analysis.ts",
     "src/lib/ui.ts"
-    ,"supabase/functions/analyze/index.ts"
   ]
 
 }


### PR DESCRIPTION
## Summary
- remove deprecated `supabase/functions/analyze/index.ts` entry from test tsconfig

## Testing
- `npm run test`

------
https://chatgpt.com/codex/tasks/task_e_6841bd03df38832bb0b3f5aceeb861be