### PR TITLE
Use env variable for Supabase token

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,8 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    env:
+      NEXT_PUBLIC_SUPABASE_ANON_KEY: ${{ secrets.NEXT_PUBLIC_SUPABASE_ANON_KEY }}
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3

--- a/README.md
+++ b/README.md
@@ -80,6 +80,12 @@ The integration provides comprehensive technology fingerprinting without requiri
 
 Simply open [Lovable](https://lovable.dev/projects/3a4c0dbb-697f-4cc3-8786-dfa109c5a225) and click on Share -> Publish.
 
+## Environment Variables
+
+The frontend needs your Supabase anonymous key to authorize requests. Set
+`NEXT_PUBLIC_SUPABASE_ANON_KEY` in your shell or `.env` file with the value from
+your Supabase project before running the app or tests.
+
 ## Can I connect a custom domain to my Lovable project?
 
 Yes, you can!

--- a/src/hooks/useAnalysisApi.ts
+++ b/src/hooks/useAnalysisApi.ts
@@ -15,13 +15,21 @@ export const useAnalysisApi = () => {
       console.log('Analyzing URL:', url);
       
       // Call the edge function directly with the URL parameter
-      const response = await fetch(`https://sxrhpwmdslxgwpqfdmxu.supabase.co/functions/v1/analyze?url=${encodeURIComponent(url)}`, {
-        method: 'GET',
-        headers: {
-          'Authorization': `Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InN4cmhwd21kc2x4Z3dwcWZkbXh1Iiwicm9sZSI6ImFub24iLCJpYXQiOjE3NDg4NTIwMDUsImV4cCI6MjA2NDQyODAwNX0.jdjgtwLQ-MGBMoRw2cLA14SzrivonF36POCC6YYUVwk`,
-          'Content-Type': 'application/json',
+      const supabaseAnonKey =
+        process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY ??
+        import.meta.env.NEXT_PUBLIC_SUPABASE_ANON_KEY ??
+        '';
+
+      const response = await fetch(
+        `https://sxrhpwmdslxgwpqfdmxu.supabase.co/functions/v1/analyze?url=${encodeURIComponent(url)}`,
+        {
+          method: 'GET',
+          headers: {
+            Authorization: `Bearer ${supabaseAnonKey}`,
+            'Content-Type': 'application/json',
+          },
         },
-      });
+      );
 
       console.log('Response status:', response.status);
 

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -15,7 +15,6 @@
     "src/lib/export.ts",
     "src/types/analysis.ts",
     "src/lib/ui.ts"
-    ,"supabase/functions/analyze/index.ts"
   ]
 
 }


### PR DESCRIPTION
## Summary
- read Supabase anon key from `process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY`
- document the required variable in the README
- expose the variable in CI so tests have it available
- omit Deno function from TypeScript compile during tests to avoid missing remote modules

## Testing
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_6841bd242680832ba3944c0530902231