### PR TITLE
docs: update node-vibrant instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,11 +98,13 @@ supabase functions serve --env-file .env
 ```
 
 
-To enable color palette extraction with `node-vibrant`, install the optional dependency:
+To enable color palette extraction with `node-vibrant`, install the optional dependency pinned to version `^4.0.3`:
 
 ```sh
-npm install node-vibrant
+npm install node-vibrant@^4.0.3
 ```
+
+The library now includes its own TypeScript definitions.
 
 
 ## How can I deploy this project?


### PR DESCRIPTION
## Summary
- specify installing `node-vibrant@^4.0.3` in README
- note that this package ships with its own TypeScript definitions

## Testing
- `npm run test`
- `npx tsc -p tsconfig.json --noEmit`

------
https://chatgpt.com/codex/tasks/task_e_6842f445400c832b92f0e6fb2cdc3d67