### PR TITLE
Fix TS syntax error in fetch options

### DIFF
--- a/src/hooks/useAnalysisApi.ts
+++ b/src/hooks/useAnalysisApi.ts
@@ -22,10 +22,10 @@ export const useAnalysisApi = () => {
         method: 'GET',
         headers: {
           'Authorization': `Bearer ${import.meta.env.VITE_SUPABASE_ANON_KEY ?? ''}`,
-          'Content-Type': 'application/json',
+          'Content-Type': 'application/json'
 
         },
-      );
+      });
 
       console.log('Response status:', response.status);
 


### PR DESCRIPTION
## Summary
- correct closing of fetch options in `useAnalysisApi`

## Testing
- `npm test`
- `npx tsc -p tsconfig.json`


------
https://chatgpt.com/codex/tasks/task_e_6843c5530530832baf76e2453df87783