### PR TITLE
Add color usage frequency grouping

### DIFF
--- a/src/components/dashboard/ui-analysis/ColorExtractionCard.tsx
+++ b/src/components/dashboard/ui-analysis/ColorExtractionCard.tsx
@@ -3,6 +3,7 @@ import React, { useState } from 'react';
 import { Box, Typography, Card, CardContent, Collapse, IconButton } from '@mui/material';
 import { Palette, ChevronDown, ChevronUp } from 'lucide-react';
 import type { AnalysisResponse } from '@/types/analysis';
+import { groupByFrequency } from '@/lib/ui';
 
 interface ColorExtractionCardProps {
   colors: AnalysisResponse['data']['ui']['colors'];
@@ -11,6 +12,16 @@ interface ColorExtractionCardProps {
 interface ColorGroup {
   name: string;
   colors: AnalysisResponse['data']['ui']['colors'];
+}
+
+interface FrequencyGroup {
+  name: string;
+  colors: AnalysisResponse['data']['ui']['colors'];
+}
+
+interface UsageGroup {
+  name: string;
+  groups: FrequencyGroup[];
 }
 
 const ColorExtractionCard: React.FC<ColorExtractionCardProps> = ({ colors }) => {
@@ -57,7 +68,7 @@ const ColorExtractionCard: React.FC<ColorExtractionCardProps> = ({ colors }) => 
   };
 
   // Group colors by usage category with improved handling
-  const groupByUsage = (): ColorGroup[] => {
+  const groupByUsage = (): UsageGroup[] => {
     const usageGroups: Record<string, AnalysisResponse['data']['ui']['colors']> = {};
     
     colors.forEach(color => {
@@ -96,7 +107,7 @@ const ColorExtractionCard: React.FC<ColorExtractionCardProps> = ({ colors }) => 
       .filter(usage => usageGroups[usage])
       .map(usage => ({
         name: usage,
-        colors: usageGroups[usage]
+        groups: groupByFrequency(usageGroups[usage])
       }));
 
     // Add any remaining groups not in the predefined order
@@ -105,7 +116,7 @@ const ColorExtractionCard: React.FC<ColorExtractionCardProps> = ({ colors }) => 
       .forEach(usage => {
         sortedGroups.push({
           name: usage,
-          colors: usageGroups[usage]
+          groups: groupByFrequency(usageGroups[usage])
         });
       });
 
@@ -171,7 +182,7 @@ const ColorExtractionCard: React.FC<ColorExtractionCardProps> = ({ colors }) => 
                 onClick={() => toggleSection(usageGroup.name)}
               >
                 <Typography variant="subtitle1" sx={{ fontWeight: 'bold', color: '#FF6B35' }}>
-                  {usageGroup.name} ({usageGroup.colors.length})
+                  {usageGroup.name} ({usageGroup.groups.reduce((t,g)=>t+g.colors.length,0)})
                 </Typography>
                 <IconButton size="small">
                   {expandedSections[usageGroup.name] ? 
@@ -184,73 +195,80 @@ const ColorExtractionCard: React.FC<ColorExtractionCardProps> = ({ colors }) => 
               {/* Collapsible Content */}
               <Collapse in={expandedSections[usageGroup.name]}>
                 <Box sx={{ mt: 2, ml: 2 }}>
-                  {groupByColorHarmony(usageGroup.colors).map((harmonyGroup, harmonyIndex) => (
-                    <Box key={harmonyIndex} sx={{ mb: 3 }}>
-                      {/* Color Harmony Subheader */}
-                      <Typography 
-                        variant="subtitle2" 
-                        sx={{ 
-                          fontWeight: 'medium', 
-                          color: 'text.secondary',
-                          mb: 1,
-                          fontSize: '0.85rem'
-                        }}
+                  {usageGroup.groups.map((freqGroup, freqIndex) => (
+                    <Box key={freqIndex} sx={{ mb: 2 }}>
+                      <Typography
+                        variant="subtitle2"
+                        sx={{ fontWeight: 'medium', mb: 1 }}
                       >
-                        {harmonyGroup.name}
+                        {freqGroup.name}
                       </Typography>
-                      
-                      {/* Colors in this harmony group */}
-                      <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 1, mb: 2 }}>
-                        {harmonyGroup.colors.map((color, colorIndex) => (
-                          <Box
-                            key={colorIndex}
+                      {groupByColorHarmony(freqGroup.colors).map((harmonyGroup, harmonyIndex) => (
+                        <Box key={harmonyIndex} sx={{ mb: 3 }}>
+                          <Typography
+                            variant="subtitle2"
                             sx={{
-                              display: 'flex',
-                              alignItems: 'center',
-                              bgcolor: 'background.paper',
-                              border: '1px solid rgba(0,0,0,0.1)',
-                              borderRadius: 1,
-                              p: 1,
-                              minWidth: 140,
+                              fontWeight: 'medium',
+                              color: 'text.secondary',
+                              mb: 1,
+                              fontSize: '0.85rem'
                             }}
                           >
-                            <Box
-                              sx={{
-                                width: 24,
-                                height: 24,
-                                backgroundColor: color.hex,
-                                borderRadius: 0.5,
-                                mr: 1,
-                                border: '1px solid rgba(0,0,0,0.1)',
-                                flexShrink: 0,
-                              }}
-                            />
-                            <Box sx={{ flex: 1, minWidth: 0 }}>
-                              <Typography 
-                                variant="caption" 
-                                sx={{ 
-                                  fontWeight: 'bold',
-                                  display: 'block',
-                                  overflow: 'hidden',
-                                  textOverflow: 'ellipsis',
+                            {harmonyGroup.name}
+                          </Typography>
+                          <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 1, mb: 2 }}>
+                            {harmonyGroup.colors.map((color, colorIndex) => (
+                              <Box
+                                key={colorIndex}
+                                sx={{
+                                  display: 'flex',
+                                  alignItems: 'center',
+                                  bgcolor: 'background.paper',
+                                  border: '1px solid rgba(0,0,0,0.1)',
+                                  borderRadius: 1,
+                                  p: 1,
+                                  minWidth: 140,
                                 }}
                               >
-                                {color.name}
-                              </Typography>
-                              <Typography 
-                                variant="caption" 
-                                color="text.secondary"
-                                sx={{ 
-                                  display: 'block',
-                                  fontSize: '0.7rem'
-                                }}
-                              >
-                                {color.hex}
-                              </Typography>
-                            </Box>
+                                <Box
+                                  sx={{
+                                    width: 24,
+                                    height: 24,
+                                    backgroundColor: color.hex,
+                                    borderRadius: 0.5,
+                                    mr: 1,
+                                    border: '1px solid rgba(0,0,0,0.1)',
+                                    flexShrink: 0,
+                                  }}
+                                />
+                                <Box sx={{ flex: 1, minWidth: 0 }}>
+                                  <Typography
+                                    variant="caption"
+                                    sx={{
+                                      fontWeight: 'bold',
+                                      display: 'block',
+                                      overflow: 'hidden',
+                                      textOverflow: 'ellipsis',
+                                    }}
+                                  >
+                                    {color.name}
+                                  </Typography>
+                                  <Typography
+                                    variant="caption"
+                                    color="text.secondary"
+                                    sx={{
+                                      display: 'block',
+                                      fontSize: '0.7rem'
+                                    }}
+                                  >
+                                    {color.hex}
+                                  </Typography>
+                                </Box>
+                              </Box>
+                            ))}
                           </Box>
-                        ))}
-                      </Box>
+                        </Box>
+                      ))}
                     </Box>
                   ))}
                 </Box>

--- a/src/lib/analysisDefaults.ts
+++ b/src/lib/analysisDefaults.ts
@@ -21,7 +21,10 @@ export function createDefaultAnalysis(url: string): AnalysisResponse {
         userExperienceScore: 0,
       },
       ui: {
-        colors: [],
+        colors: [
+          { name: 'Primary Text', hex: '#000000', usage: 'Text', count: 0 },
+          { name: 'Background', hex: '#FFFFFF', usage: 'Background', count: 0 },
+        ],
         fonts: [],
         images: [],
         imageAnalysis: {

--- a/src/lib/ui.ts
+++ b/src/lib/ui.ts
@@ -1,3 +1,37 @@
 export function dashIfEmpty(value: any): string {
   return value ? String(value) : '\u2014';
 }
+
+export interface ColorWithCount {
+  name: string;
+  hex: string;
+  usage: string;
+  count: number;
+}
+
+export interface FrequencyGroup {
+  name: string;
+  colors: ColorWithCount[];
+}
+
+export function groupByFrequency(colors: ColorWithCount[]): FrequencyGroup[] {
+  const sorted = [...colors].sort((a, b) => b.count - a.count);
+
+  let mostCount = 3;
+  if (sorted.length < 3) mostCount = sorted.length;
+  else if (sorted.length > 5) mostCount = 5;
+  else mostCount = sorted.length;
+
+  const mostUsed = sorted.slice(0, mostCount);
+  const remaining = sorted.slice(mostCount);
+  const supportingCount = Math.ceil(remaining.length / 2);
+  const supporting = remaining.slice(0, supportingCount);
+  const accent = remaining.slice(supportingCount);
+
+  const groups: FrequencyGroup[] = [];
+  if (mostUsed.length) groups.push({ name: 'Most Used', colors: mostUsed });
+  if (supporting.length) groups.push({ name: 'Supporting Colors', colors: supporting });
+  if (accent.length) groups.push({ name: 'Accent Colors', colors: accent });
+
+  return groups;
+}

--- a/src/types/analysis.ts
+++ b/src/types/analysis.ts
@@ -65,6 +65,7 @@ export interface AnalysisResponse {
         name: string;
         hex: string;
         usage: string;
+        count: number;
       }>;
       fonts: Array<{
         name: string;

--- a/supabase/functions/analyze/index.ts
+++ b/supabase/functions/analyze/index.ts
@@ -49,8 +49,8 @@ function extractContrastIssues(html: string): Array<{element: string, issue: str
 }
 
 // Enhanced color extraction with usage-based categorization
-function extractCssColors(html: string): Array<{name: string, hex: string, usage: string}> {
-  const colors: Array<{name: string, hex: string, usage: string}> = [];
+function extractCssColors(html: string): Array<{name: string, hex: string, usage: string, count: number}> {
+  const colors: Array<{name: string, hex: string, usage: string, count: number}> = [];
   const colorCounts: Record<string, number> = {};
   
   try {
@@ -102,7 +102,8 @@ function extractCssColors(html: string): Array<{name: string, hex: string, usage
         colors.push({
           name: getColorName(hex),
           hex: hex,
-          usage: 'Background'
+          usage: 'Background',
+          count: colorCounts[hex] || 0
         });
         processedColors.add(hex);
       }
@@ -114,7 +115,8 @@ function extractCssColors(html: string): Array<{name: string, hex: string, usage
         colors.push({
           name: getColorName(hex),
           hex: hex,
-          usage: 'Text'
+          usage: 'Text',
+          count: colorCounts[hex] || 0
         });
         processedColors.add(hex);
       }
@@ -126,7 +128,8 @@ function extractCssColors(html: string): Array<{name: string, hex: string, usage
         colors.push({
           name: getColorName(hex),
           hex: hex,
-          usage: 'Border'
+          usage: 'Border',
+          count: colorCounts[hex] || 0
         });
         processedColors.add(hex);
       }
@@ -138,7 +141,8 @@ function extractCssColors(html: string): Array<{name: string, hex: string, usage
         colors.push({
           name: getColorName(hex),
           hex: hex,
-          usage: 'Accent'
+          usage: 'Accent',
+          count: colorCounts[hex] || 0
         });
         processedColors.add(hex);
       }
@@ -154,7 +158,8 @@ function extractCssColors(html: string): Array<{name: string, hex: string, usage
         colors.push({
           name: getColorName(hex),
           hex: hex,
-          usage: 'Theme'
+          usage: 'Theme',
+          count: colorCounts[hex] || 0
         });
         processedColors.add(hex);
       }
@@ -163,8 +168,8 @@ function extractCssColors(html: string): Array<{name: string, hex: string, usage
     // Fallback colors if nothing found
     if (colors.length === 0) {
       colors.push(
-        { name: 'Primary Text', hex: '#000000', usage: 'Text' },
-        { name: 'Background', hex: '#FFFFFF', usage: 'Background' }
+        { name: 'Primary Text', hex: '#000000', usage: 'Text', count: 0 },
+        { name: 'Background', hex: '#FFFFFF', usage: 'Background', count: 0 }
       );
     }
 
@@ -172,8 +177,8 @@ function extractCssColors(html: string): Array<{name: string, hex: string, usage
     console.error('Color extraction error:', error);
     // Return fallback colors
     return [
-      { name: 'Primary Text', hex: '#000000', usage: 'Text' },
-      { name: 'Background', hex: '#FFFFFF', usage: 'Background' }
+      { name: 'Primary Text', hex: '#000000', usage: 'Text', count: 0 },
+      { name: 'Background', hex: '#FFFFFF', usage: 'Background', count: 0 }
     ];
   }
 
@@ -740,7 +745,7 @@ const analyzeWebsite = async (url: string) => {
           userExperienceScore: 50,
         },
         ui: {
-          colors: [{ name: 'Primary', hex: '#000000', usage: 'Text content' }],
+          colors: [{ name: 'Primary', hex: '#000000', usage: 'Text content', count: 0 }],
           fonts: [{ name: 'System Font', category: 'Sans-serif', usage: 'Body text', weight: '400' }],
           images: [{ type: 'Total Images', count: 0, format: 'Mixed', totalSize: '0KB' }],
           imageAnalysis: {
@@ -872,8 +877,8 @@ const buildColorObjects = (html: string) => {
   const extractedColors = extractCssColors(html);
   if (extractedColors.length === 0) {
     return [
-      { name: 'Primary Text', hex: '#000000', usage: 'Text' },
-      { name: 'Background', hex: '#FFFFFF', usage: 'Background' },
+      { name: 'Primary Text', hex: '#000000', usage: 'Text', count: 0 },
+      { name: 'Background', hex: '#FFFFFF', usage: 'Background', count: 0 },
     ];
   }
   return extractedColors;

--- a/tests/colorFrequency.test.js
+++ b/tests/colorFrequency.test.js
@@ -1,0 +1,21 @@
+import assert from 'node:assert';
+import { groupByFrequency } from '../dist/lib/ui.js';
+
+const colors = [
+  { name: 'A', hex: '#111111', usage: 'Text', count: 8 },
+  { name: 'B', hex: '#222222', usage: 'Text', count: 6 },
+  { name: 'C', hex: '#333333', usage: 'Text', count: 4 },
+  { name: 'D', hex: '#444444', usage: 'Text', count: 2 },
+  { name: 'E', hex: '#555555', usage: 'Text', count: 1 },
+];
+
+const groups = groupByFrequency(colors);
+assert.strictEqual(groups[0].name, 'Most Used');
+assert.ok(groups[0].colors.length >= 3);
+if (groups.length > 1) {
+  assert.strictEqual(groups[1].name, 'Supporting Colors');
+}
+if (groups.length > 2) {
+  assert.strictEqual(groups[2].name, 'Accent Colors');
+}
+console.log('color frequency grouping test passed');

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -9,6 +9,7 @@ node tests/securityHeaders.test.js
 node tests/design.test.js
 node tests/social.test.js
 node tests/ui.test.js
+node tests/colorFrequency.test.js
 node tests/export.test.js
 node tests/seo.test.js
 

--- a/tests/ui.test.js
+++ b/tests/ui.test.js
@@ -1,7 +1,22 @@
 import assert from 'node:assert';
-import { dashIfEmpty } from '../dist/lib/ui.js';
+import { dashIfEmpty, groupByFrequency } from '../dist/lib/ui.js';
 
 assert.strictEqual(dashIfEmpty('abc'), 'abc');
 assert.strictEqual(dashIfEmpty(''), '\u2014');
 assert.strictEqual(dashIfEmpty(null), '\u2014');
+
+// frequency grouping
+const sampleColors = [
+  { name: 'A', hex: '#111111', usage: 'Text', count: 10 },
+  { name: 'B', hex: '#222222', usage: 'Text', count: 5 },
+  { name: 'C', hex: '#333333', usage: 'Text', count: 3 },
+  { name: 'D', hex: '#444444', usage: 'Text', count: 1 },
+];
+
+const freqGroups = groupByFrequency(sampleColors);
+assert.strictEqual(freqGroups[0].name, 'Most Used');
+assert.ok(freqGroups[0].colors.length >= 3);
+if (freqGroups.length > 1) {
+  assert.strictEqual(freqGroups[1].name, 'Supporting Colors');
+}
 console.log('ui utils test passed');


### PR DESCRIPTION
## Summary
- add `count` field to color data
- provide default colors with count
- expose `groupByFrequency` util for colors
- include count in edge extraction and fallback
- group UI colors by frequency then harmony
- test new frequency grouping logic

## Testing
- `npm run test`
- `npx tsc -p tsconfig.json --noEmit`

------
https://chatgpt.com/codex/tasks/task_e_684423eda5c8832b885e5b645aece167