### PR TITLE
Fix responsive dashboard tabs

### DIFF
--- a/src/components/DashboardContent.tsx
+++ b/src/components/DashboardContent.tsx
@@ -21,7 +21,7 @@ const DashboardContent = () => {
       
       <Paper elevation={3} sx={{ p: 3, borderRadius: 2 }}>
         <Tabs defaultValue="overview" className="w-full">
-          <TabsList className="grid w-full grid-cols-6 mb-6">
+          <TabsList className="grid w-full grid-cols-6 sm:grid-cols-3 gap-2 mb-6">
             <TabsTrigger value="overview">Overview</TabsTrigger>
             <TabsTrigger value="ui">User Interface</TabsTrigger>
             <TabsTrigger value="performance">Performance & Security</TabsTrigger>

--- a/src/components/ui/tabs.tsx
+++ b/src/components/ui/tabs.tsx
@@ -27,7 +27,7 @@ const TabsTrigger = React.forwardRef<
   <TabsPrimitive.Trigger
     ref={ref}
     className={cn(
-      "inline-flex items-center justify-center whitespace-nowrap rounded-sm px-3 py-1.5 text-sm font-medium ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:bg-background data-[state=active]:text-foreground data-[state=active]:shadow-sm",
+      "inline-flex items-center justify-center rounded-sm px-3 py-1.5 text-sm font-medium ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:bg-background data-[state=active]:text-foreground data-[state=active]:shadow-sm",
       className
     )}
     {...props}


### PR DESCRIPTION
## Summary
- allow dashboard tabs to wrap by removing `whitespace-nowrap`
- adjust tab list to use responsive grid columns

## Testing
- `npm run test`
- `npx tsc -p tsconfig.json --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_6844329ab590832b864b78a6311daadc