### PR TITLE
Fix MUI Grid2 import path

### DIFF
--- a/src/components/dashboard/ComplianceTab.tsx
+++ b/src/components/dashboard/ComplianceTab.tsx
@@ -1,7 +1,7 @@
 
 import React from 'react';
 import { Box, Typography, Card, CardContent, Alert, CircularProgress, Chip } from '@mui/material';
-import Grid from '@mui/material/Grid2';
+import Grid from '@mui/material/Unstable_Grid2';
 import type { AnalysisResponse } from '@/types/analysis';
 import { dashIfEmpty } from '../../lib/ui';
 

--- a/src/components/dashboard/ContentAnalysisTab.tsx
+++ b/src/components/dashboard/ContentAnalysisTab.tsx
@@ -1,7 +1,7 @@
 
 import React from 'react';
 import { Box, Typography, Card, CardContent, LinearProgress } from '@mui/material';
-import Grid from '@mui/material/Grid2';
+import Grid from '@mui/material/Unstable_Grid2';
 import { ChartContainer, ChartTooltip, ChartTooltipContent } from '../ui/chart';
 import { PieChart, Pie, Cell, ResponsiveContainer, BarChart, Bar, XAxis, YAxis } from 'recharts';
 

--- a/src/components/dashboard/OverviewTab.tsx
+++ b/src/components/dashboard/OverviewTab.tsx
@@ -1,7 +1,7 @@
 
 import React from 'react';
 import { Box, Typography, Card, CardContent, CircularProgress, Alert } from '@mui/material';
-import Grid from '@mui/material/Grid2';
+import Grid from '@mui/material/Unstable_Grid2';
 import { TrendingUp, Users, Clock, Star } from 'lucide-react';
 import type { AnalysisResponse } from '@/types/analysis';
 

--- a/src/components/dashboard/PerformanceTab.tsx
+++ b/src/components/dashboard/PerformanceTab.tsx
@@ -1,7 +1,7 @@
 
 import React from 'react';
 import { Box, Typography, Card, CardContent, LinearProgress, CircularProgress, Alert, Chip } from '@mui/material';
-import Grid from '@mui/material/Grid2';
+import Grid from '@mui/material/Unstable_Grid2';
 import { ChartContainer, ChartTooltip, ChartTooltipContent } from '../ui/chart';
 import { BarChart, Bar, XAxis, YAxis, ResponsiveContainer } from 'recharts';
 import { Shield, Smartphone, Zap } from 'lucide-react';

--- a/src/components/dashboard/SEOAnalysisTab.tsx
+++ b/src/components/dashboard/SEOAnalysisTab.tsx
@@ -1,7 +1,7 @@
 
 import React from 'react';
 import { Box, Typography, Card, CardContent, Chip, CircularProgress, Alert } from '@mui/material';
-import Grid from '@mui/material/Grid2';
+import Grid from '@mui/material/Unstable_Grid2';
 import { CheckCircle, AlertCircle, XCircle } from 'lucide-react';
 import type { AnalysisResponse } from '@/types/analysis';
 

--- a/src/components/dashboard/TechTab.tsx
+++ b/src/components/dashboard/TechTab.tsx
@@ -1,7 +1,7 @@
 
 import React from 'react';
 import { Box, Typography, Card, CardContent, Chip, CircularProgress, Alert } from '@mui/material';
-import Grid from '@mui/material/Grid2';
+import Grid from '@mui/material/Unstable_Grid2';
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '../ui/table';
 import { Shield, Globe, Server, Database, Code, Layers, Zap, Activity, BarChart } from 'lucide-react';
 import type { AnalysisResponse } from '@/types/analysis';

--- a/src/components/dashboard/UIAnalysisTab.tsx
+++ b/src/components/dashboard/UIAnalysisTab.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Box, Typography, CircularProgress, Alert } from '@mui/material';
-import Grid from '@mui/material/Grid2';
+import Grid from '@mui/material/Unstable_Grid2';
 import type { AnalysisResponse } from '@/types/analysis';
 import ColorExtractionCard from './ui-analysis/ColorExtractionCard';
 import FontAnalysisCard from './ui-analysis/FontAnalysisCard';

--- a/src/components/dashboard/ui-analysis/ImageAnalysisCard.tsx
+++ b/src/components/dashboard/ui-analysis/ImageAnalysisCard.tsx
@@ -1,7 +1,7 @@
 
 import React, { useState } from 'react';
 import { Box, Typography, Card, CardContent } from '@mui/material';
-import Grid from '@mui/material/Grid2';
+import Grid from '@mui/material/Unstable_Grid2';
 import { Image } from 'lucide-react';
 import type { AnalysisResponse } from '@/types/analysis';
 import ExpandableImageBox from './ExpandableImageBox';


### PR DESCRIPTION
## Summary
- use `@mui/material/Unstable_Grid2` for all dashboard imports

## Testing
- `npm run test` *(fails: Cannot find type definition file for 'd3-array', etc.)*
- `npx tsc -p tsconfig.json --noEmit` *(fails: command could not run)*

------
https://chatgpt.com/codex/tasks/task_e_6844fd47fa50832b96cbb7465716807f