### PR TITLE
Fix dashboard card widths

### DIFF
--- a/src/components/dashboard/OverviewTab.tsx
+++ b/src/components/dashboard/OverviewTab.tsx
@@ -77,7 +77,7 @@ const OverviewTab: React.FC<OverviewTabProps> = ({ data, loading, error }) => {
         {metrics.map((metric, index) => {
           const IconComponent = metric.icon;
           return (
-            <Grid xs={12} sm={6} md={3} key={index}>
+            <Grid xs={12} sm={6} md={6} key={index}>
               <Card sx={{ height: '100%', borderRadius: 2 }}>
                 <CardContent sx={{ p: 3 }}>
                   <Box sx={{ display: 'flex', alignItems: 'center', mb: 2 }}>

--- a/src/components/dashboard/UIAnalysisTab.tsx
+++ b/src/components/dashboard/UIAnalysisTab.tsx
@@ -61,7 +61,7 @@ const UIAnalysisTab: React.FC<UIAnalysisTabProps> = ({ data, loading, error }) =
         </Grid>
 
         {/* Contrast Warnings */}
-        <Grid xs={12}>
+        <Grid xs={12} md={6}>
           <ContrastWarningsCard issues={data.data.ui.contrastIssues} />
         </Grid>
 


### PR DESCRIPTION
## Summary
- tweak Overview metrics grid spacing to show 2 cards per row
- make contrast warnings card use same width as other UI analysis cards

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684528290728832bbc3f3dec5092ecf8