### PR TITLE
Fix dashboard card widths

### DIFF
--- a/src/components/dashboard/OverviewTab.tsx
+++ b/src/components/dashboard/OverviewTab.tsx
@@ -77,7 +77,7 @@ const OverviewTab: React.FC<OverviewTabProps> = ({ data, loading, error }) => {
         {metrics.map((metric, index) => {
           const IconComponent = metric.icon;
           return (
-            <Grid xs={12} sm={6} md={3} key={index}>
+            <Grid item xs={12} sm={6} md={6} key={index}>
               <Card sx={{ height: '100%', borderRadius: 2 }}>
                 <CardContent sx={{ p: 3 }}>
                   <Box sx={{ display: 'flex', alignItems: 'center', mb: 2 }}>

--- a/src/components/dashboard/UIAnalysisTab.tsx
+++ b/src/components/dashboard/UIAnalysisTab.tsx
@@ -51,25 +51,25 @@ const UIAnalysisTab: React.FC<UIAnalysisTabProps> = ({ data, loading, error }) =
 
       <Grid container spacing={3}>
         {/* Color Extraction */}
-        <Grid xs={12} md={6}>
+        <Grid item xs={12} md={6}>
           <ColorExtractionCard colors={colors} />
         </Grid>
 
         {/* Font Analysis */}
-        <Grid xs={12} md={6}>
+        <Grid item xs={12} md={6}>
           <FontAnalysisCard fonts={fonts} />
         </Grid>
 
         {/* Contrast Warnings */}
-        <Grid xs={12}>
+        <Grid item xs={12} md={6}>
           <ContrastWarningsCard issues={data.data.ui.contrastIssues} />
         </Grid>
 
         {/* Image Analysis */}
-        <Grid xs={12}>
-          <ImageAnalysisCard 
-            images={images} 
-            imageAnalysis={imageAnalysis} 
+        <Grid item xs={12}>
+          <ImageAnalysisCard
+            images={images}
+            imageAnalysis={imageAnalysis}
           />
         </Grid>
       </Grid>


### PR DESCRIPTION
## Summary
- tweak Overview metrics grid spacing to show 2 cards per row
- make contrast warnings card use same width as other UI analysis cards
- add `item` prop to all dashboard grid items for consistent sizing

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684528290728832bbc3f3dec5092ecf8