### PR TITLE
Fix overview tab layout

### DIFF
--- a/src/components/dashboard/OverviewTab.tsx
+++ b/src/components/dashboard/OverviewTab.tsx
@@ -73,12 +73,25 @@ const OverviewTab: React.FC<OverviewTabProps> = ({ data, loading, error }) => {
         Website Overview - {data.url}
       </Typography>
       
-      <Grid container spacing={3}>
+      <Grid
+        container
+        spacing={3}
+        alignItems="stretch"
+        columns={{ xs: 12, sm: 12, md: 12 }}
+      >
         {metrics.map((metric, index) => {
           const IconComponent = metric.icon;
           return (
-            <Grid xs={12} sm={6} md={3} key={index}>
-              <Card sx={{ height: '100%', borderRadius: 2 }}>
+            <Grid
+              item
+              xs={6}
+              sm={6}
+              md={6}
+              lg={6}
+              key={index}
+              sx={{ display: 'flex' }}
+            >
+              <Card sx={{ height: '100%', borderRadius: 2, flexGrow: 1 }}>
                 <CardContent sx={{ p: 3 }}>
                   <Box sx={{ display: 'flex', alignItems: 'center', mb: 2 }}>
                     <Box

--- a/src/components/dashboard/UIAnalysisTab.tsx
+++ b/src/components/dashboard/UIAnalysisTab.tsx
@@ -49,27 +49,27 @@ const UIAnalysisTab: React.FC<UIAnalysisTabProps> = ({ data, loading, error }) =
         User Interface Analysis
       </Typography>
 
-      <Grid container spacing={3}>
+      <Grid container spacing={3} alignItems="stretch" columns={{ xs: 12, md: 12 }}>
         {/* Color Extraction */}
-        <Grid xs={12} md={6}>
+        <Grid item xs={12} md={6} lg={6} sx={{ display: 'flex' }}>
           <ColorExtractionCard colors={colors} />
         </Grid>
 
         {/* Font Analysis */}
-        <Grid xs={12} md={6}>
+        <Grid item xs={12} md={6} lg={6} sx={{ display: 'flex' }}>
           <FontAnalysisCard fonts={fonts} />
         </Grid>
 
         {/* Contrast Warnings */}
-        <Grid xs={12}>
+        <Grid item xs={12} md={6} lg={6} sx={{ display: 'flex' }}>
           <ContrastWarningsCard issues={data.data.ui.contrastIssues} />
         </Grid>
 
         {/* Image Analysis */}
-        <Grid xs={12}>
-          <ImageAnalysisCard 
-            images={images} 
-            imageAnalysis={imageAnalysis} 
+        <Grid item xs={12} sx={{ display: 'flex' }}>
+          <ImageAnalysisCard
+            images={images}
+            imageAnalysis={imageAnalysis}
           />
         </Grid>
       </Grid>


### PR DESCRIPTION
## Summary
- keep overview metric cards stretched for consistent size
- standardize widths across UI analysis cards
- render overview metrics as two columns

## Testing
- `npm run test`
- `npx tsc -p tsconfig.json --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_684528290728832bbc3f3dec5092ecf8