### PR TITLE
Fix overview tab layout

### DIFF
--- a/src/components/dashboard/ComplianceTab.tsx
+++ b/src/components/dashboard/ComplianceTab.tsx
@@ -1,7 +1,16 @@
-import React from 'react';
-import { Box, Typography, Grid, Card, CardContent, Alert, CircularProgress, Chip } from '@mui/material';
-import type { AnalysisResponse } from '@/types/analysis';
-import { dashIfEmpty } from '../../lib/ui';
+import React from "react";
+import {
+  Box,
+  Typography,
+  Grid,
+  Card,
+  CardContent,
+  Alert,
+  CircularProgress,
+  Chip,
+} from "@mui/material";
+import type { AnalysisResponse } from "@/types/analysis";
+import { dashIfEmpty } from "../../lib/ui";
 
 interface ComplianceTabProps {
   data: AnalysisResponse | null;
@@ -9,12 +18,25 @@ interface ComplianceTabProps {
   error: string | null;
 }
 
-const ComplianceTab: React.FC<ComplianceTabProps> = ({ data, loading, error }) => {
+const ComplianceTab: React.FC<ComplianceTabProps> = ({
+  data,
+  loading,
+  error,
+}) => {
   if (loading) {
     return (
-      <Box sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center', py: 8 }}>
+      <Box
+        sx={{
+          display: "flex",
+          justifyContent: "center",
+          alignItems: "center",
+          py: 8,
+        }}
+      >
         <CircularProgress size={60} />
-        <Typography variant="h6" sx={{ ml: 2 }}>Analyzing compliance...</Typography>
+        <Typography variant="h6" sx={{ ml: 2 }}>
+          Analyzing compliance...
+        </Typography>
       </Box>
     );
   }
@@ -38,22 +60,26 @@ const ComplianceTab: React.FC<ComplianceTabProps> = ({ data, loading, error }) =
   const { securityHeaders } = data;
   const tech = data.data.technical;
   const violations = tech.accessibility.violations;
-  const social = tech.social || { hasOpenGraph: false, hasTwitterCard: false, hasShareButtons: false };
+  const social = tech.social || {
+    hasOpenGraph: false,
+    hasTwitterCard: false,
+    hasShareButtons: false,
+  };
   const cookies = tech.cookies || { hasCookieScript: false, scripts: [] };
   const minify = tech.minification || { cssMinified: false, jsMinified: false };
   const links = tech.linkIssues || { brokenLinks: [], mixedContentLinks: [] };
 
   return (
     <Box>
-      <Typography variant="h5" gutterBottom sx={{ fontWeight: 'bold', mb: 3 }}>
+      <Typography variant="h5" gutterBottom sx={{ fontWeight: "bold", mb: 3 }}>
         Compliance Audits
       </Typography>
 
       <Grid container spacing={3}>
-        <Grid xs={12} md={6}>
+        <Grid item xs={12} md={6}>
           <Card sx={{ borderRadius: 2 }}>
             <CardContent sx={{ p: 3 }}>
-              <Typography variant="h6" gutterBottom sx={{ fontWeight: 'bold' }}>
+              <Typography variant="h6" gutterBottom sx={{ fontWeight: "bold" }}>
                 Security Headers
               </Typography>
               <Box component="ul" sx={{ pl: 2 }}>
@@ -67,10 +93,10 @@ const ComplianceTab: React.FC<ComplianceTabProps> = ({ data, loading, error }) =
           </Card>
         </Grid>
 
-        <Grid xs={12} md={6}>
+        <Grid item xs={12} md={6}>
           <Card sx={{ borderRadius: 2 }}>
             <CardContent sx={{ p: 3 }}>
-              <Typography variant="h6" gutterBottom sx={{ fontWeight: 'bold' }}>
+              <Typography variant="h6" gutterBottom sx={{ fontWeight: "bold" }}>
                 Accessibility Violations
               </Typography>
               {violations.length === 0 ? (
@@ -79,7 +105,7 @@ const ComplianceTab: React.FC<ComplianceTabProps> = ({ data, loading, error }) =
                 <Box component="ul" sx={{ pl: 2 }}>
                   {violations.map((v, i) => (
                     <Typography component="li" variant="body2" key={i}>
-                      {v.id} {v.description ? `- ${v.description}` : ''}
+                      {v.id} {v.description ? `- ${v.description}` : ""}
                     </Typography>
                   ))}
                 </Box>
@@ -88,25 +114,38 @@ const ComplianceTab: React.FC<ComplianceTabProps> = ({ data, loading, error }) =
           </Card>
         </Grid>
 
-        <Grid xs={12}>
+        <Grid item xs={12}>
           <Card sx={{ borderRadius: 2 }}>
             <CardContent sx={{ p: 3 }}>
-              <Typography variant="h6" gutterBottom sx={{ fontWeight: 'bold' }}>
+              <Typography variant="h6" gutterBottom sx={{ fontWeight: "bold" }}>
                 Other Checks
               </Typography>
-              <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 1, mb: 2 }}>
-                <Chip label={`Open Graph: ${social.hasOpenGraph ? 'yes' : dashIfEmpty('')}` } />
-                <Chip label={`Twitter Card: ${social.hasTwitterCard ? 'yes' : dashIfEmpty('')}` } />
-                <Chip label={`Share Buttons: ${social.hasShareButtons ? 'yes' : dashIfEmpty('')}` } />
-                <Chip label={`Cookie Script: ${cookies.hasCookieScript ? 'yes' : dashIfEmpty('')}` } />
-                <Chip label={`CSS Minified: ${minify.cssMinified ? 'yes' : dashIfEmpty('')}` } />
-                <Chip label={`JS Minified: ${minify.jsMinified ? 'yes' : dashIfEmpty('')}` } />
+              <Box sx={{ display: "flex", flexWrap: "wrap", gap: 1, mb: 2 }}>
+                <Chip
+                  label={`Open Graph: ${social.hasOpenGraph ? "yes" : dashIfEmpty("")}`}
+                />
+                <Chip
+                  label={`Twitter Card: ${social.hasTwitterCard ? "yes" : dashIfEmpty("")}`}
+                />
+                <Chip
+                  label={`Share Buttons: ${social.hasShareButtons ? "yes" : dashIfEmpty("")}`}
+                />
+                <Chip
+                  label={`Cookie Script: ${cookies.hasCookieScript ? "yes" : dashIfEmpty("")}`}
+                />
+                <Chip
+                  label={`CSS Minified: ${minify.cssMinified ? "yes" : dashIfEmpty("")}`}
+                />
+                <Chip
+                  label={`JS Minified: ${minify.jsMinified ? "yes" : dashIfEmpty("")}`}
+                />
               </Box>
               <Typography variant="body2">
                 <strong>Broken Links:</strong> {links.brokenLinks.length || 0}
               </Typography>
               <Typography variant="body2">
-                <strong>Mixed Content Links:</strong> {links.mixedContentLinks.length || 0}
+                <strong>Mixed Content Links:</strong>{" "}
+                {links.mixedContentLinks.length || 0}
               </Typography>
             </CardContent>
           </Card>

--- a/src/components/dashboard/ContentAnalysisTab.tsx
+++ b/src/components/dashboard/ContentAnalysisTab.tsx
@@ -1,39 +1,54 @@
-
-import React from 'react';
-import { Box, Typography, Grid, Card, CardContent, LinearProgress } from '@mui/material';
-import { ChartContainer, ChartTooltip, ChartTooltipContent } from '../ui/chart';
-import { PieChart, Pie, Cell, ResponsiveContainer, BarChart, Bar, XAxis, YAxis } from 'recharts';
+import React from "react";
+import {
+  Box,
+  Typography,
+  Grid,
+  Card,
+  CardContent,
+  LinearProgress,
+} from "@mui/material";
+import { ChartContainer, ChartTooltip, ChartTooltipContent } from "../ui/chart";
+import {
+  PieChart,
+  Pie,
+  Cell,
+  ResponsiveContainer,
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+} from "recharts";
 
 const ContentAnalysisTab = () => {
   const contentTypes = [
-    { name: 'Text', value: 65, color: '#2196F3' },
-    { name: 'Images', value: 20, color: '#4CAF50' },
-    { name: 'Videos', value: 10, color: '#FF9800' },
-    { name: 'Links', value: 5, color: '#9C27B0' },
+    { name: "Text", value: 65, color: "#2196F3" },
+    { name: "Images", value: 20, color: "#4CAF50" },
+    { name: "Videos", value: 10, color: "#FF9800" },
+    { name: "Links", value: 5, color: "#9C27B0" },
   ];
 
   const readabilityData = [
-    { metric: 'Flesch Reading Ease', score: 78 },
-    { metric: 'Grade Level', score: 85 },
-    { metric: 'Sentence Length', score: 92 },
-    { metric: 'Word Complexity', score: 88 },
+    { metric: "Flesch Reading Ease", score: 78 },
+    { metric: "Grade Level", score: 85 },
+    { metric: "Sentence Length", score: 92 },
+    { metric: "Word Complexity", score: 88 },
   ];
 
   const chartConfig = {
-    score: { label: 'Score', color: '#2196F3' }
+    score: { label: "Score", color: "#2196F3" },
   };
 
   return (
     <Box>
-      <Typography variant="h5" gutterBottom sx={{ fontWeight: 'bold', mb: 3 }}>
+      <Typography variant="h5" gutterBottom sx={{ fontWeight: "bold", mb: 3 }}>
         Content Analysis
       </Typography>
 
       <Grid container spacing={3}>
-        <Grid xs={12} md={6}>
-          <Card sx={{ borderRadius: 2, height: '400px' }}>
-            <CardContent sx={{ p: 3, height: '100%' }}>
-              <Typography variant="h6" gutterBottom sx={{ fontWeight: 'bold' }}>
+        <Grid item xs={12} md={6}>
+          <Card sx={{ borderRadius: 2, height: "400px" }}>
+            <CardContent sx={{ p: 3, height: "100%" }}>
+              <Typography variant="h6" gutterBottom sx={{ fontWeight: "bold" }}>
                 Content Distribution
               </Typography>
               <ChartContainer config={chartConfig} className="h-80">
@@ -45,7 +60,9 @@ const ContentAnalysisTab = () => {
                     outerRadius={80}
                     fill="#8884d8"
                     dataKey="value"
-                    label={({ name, percent }) => `${name} ${(percent * 100).toFixed(0)}%`}
+                    label={({ name, percent }) =>
+                      `${name} ${(percent * 100).toFixed(0)}%`
+                    }
                   >
                     {contentTypes.map((entry, index) => (
                       <Cell key={`cell-${index}`} fill={entry.color} />
@@ -58,14 +75,17 @@ const ContentAnalysisTab = () => {
           </Card>
         </Grid>
 
-        <Grid xs={12} md={6}>
-          <Card sx={{ borderRadius: 2, height: '400px' }}>
-            <CardContent sx={{ p: 3, height: '100%' }}>
-              <Typography variant="h6" gutterBottom sx={{ fontWeight: 'bold' }}>
+        <Grid item xs={12} md={6}>
+          <Card sx={{ borderRadius: 2, height: "400px" }}>
+            <CardContent sx={{ p: 3, height: "100%" }}>
+              <Typography variant="h6" gutterBottom sx={{ fontWeight: "bold" }}>
                 Readability Analysis
               </Typography>
               <ChartContainer config={chartConfig} className="h-80">
-                <BarChart data={readabilityData} margin={{ top: 20, right: 30, left: 20, bottom: 5 }}>
+                <BarChart
+                  data={readabilityData}
+                  margin={{ top: 20, right: 30, left: 20, bottom: 5 }}
+                >
                   <XAxis dataKey="metric" tick={{ fontSize: 10 }} />
                   <YAxis domain={[0, 100]} />
                   <ChartTooltip content={<ChartTooltipContent />} />
@@ -78,77 +98,133 @@ const ContentAnalysisTab = () => {
       </Grid>
 
       <Grid container spacing={3} sx={{ mt: 1 }}>
-        <Grid xs={12} md={8}>
+        <Grid item xs={12} md={8}>
           <Card sx={{ borderRadius: 2 }}>
             <CardContent sx={{ p: 3 }}>
-              <Typography variant="h6" gutterBottom sx={{ fontWeight: 'bold' }}>
+              <Typography variant="h6" gutterBottom sx={{ fontWeight: "bold" }}>
                 Content Quality Metrics
               </Typography>
-              
+
               <Box sx={{ mb: 3 }}>
-                <Box sx={{ display: 'flex', justifyContent: 'space-between', mb: 1 }}>
+                <Box
+                  sx={{
+                    display: "flex",
+                    justifyContent: "space-between",
+                    mb: 1,
+                  }}
+                >
                   <Typography variant="body2">Keyword Density</Typography>
                   <Typography variant="body2">2.3%</Typography>
                 </Box>
-                <LinearProgress variant="determinate" value={75} sx={{ height: 8, borderRadius: 4 }} />
+                <LinearProgress
+                  variant="determinate"
+                  value={75}
+                  sx={{ height: 8, borderRadius: 4 }}
+                />
               </Box>
 
               <Box sx={{ mb: 3 }}>
-                <Box sx={{ display: 'flex', justifyContent: 'space-between', mb: 1 }}>
+                <Box
+                  sx={{
+                    display: "flex",
+                    justifyContent: "space-between",
+                    mb: 1,
+                  }}
+                >
                   <Typography variant="body2">Content Freshness</Typography>
                   <Typography variant="body2">85%</Typography>
                 </Box>
-                <LinearProgress variant="determinate" value={85} sx={{ height: 8, borderRadius: 4 }} />
+                <LinearProgress
+                  variant="determinate"
+                  value={85}
+                  sx={{ height: 8, borderRadius: 4 }}
+                />
               </Box>
 
               <Box sx={{ mb: 3 }}>
-                <Box sx={{ display: 'flex', justifyContent: 'space-between', mb: 1 }}>
+                <Box
+                  sx={{
+                    display: "flex",
+                    justifyContent: "space-between",
+                    mb: 1,
+                  }}
+                >
                   <Typography variant="body2">Engagement Score</Typography>
                   <Typography variant="body2">78%</Typography>
                 </Box>
-                <LinearProgress variant="determinate" value={78} sx={{ height: 8, borderRadius: 4 }} />
+                <LinearProgress
+                  variant="determinate"
+                  value={78}
+                  sx={{ height: 8, borderRadius: 4 }}
+                />
               </Box>
 
               <Box>
-                <Box sx={{ display: 'flex', justifyContent: 'space-between', mb: 1 }}>
+                <Box
+                  sx={{
+                    display: "flex",
+                    justifyContent: "space-between",
+                    mb: 1,
+                  }}
+                >
                   <Typography variant="body2">Originality</Typography>
                   <Typography variant="body2">94%</Typography>
                 </Box>
-                <LinearProgress variant="determinate" value={94} sx={{ height: 8, borderRadius: 4 }} />
+                <LinearProgress
+                  variant="determinate"
+                  value={94}
+                  sx={{ height: 8, borderRadius: 4 }}
+                />
               </Box>
             </CardContent>
           </Card>
         </Grid>
 
-        <Grid xs={12} md={4}>
+        <Grid item xs={12} md={4}>
           <Card sx={{ borderRadius: 2 }}>
             <CardContent sx={{ p: 3 }}>
-              <Typography variant="h6" gutterBottom sx={{ fontWeight: 'bold' }}>
+              <Typography variant="h6" gutterBottom sx={{ fontWeight: "bold" }}>
                 Content Statistics
               </Typography>
-              
+
               <Box sx={{ mb: 2 }}>
-                <Typography variant="body2" color="text.secondary">Total Words</Typography>
-                <Typography variant="h6" sx={{ fontWeight: 'bold' }}>1,247</Typography>
+                <Typography variant="body2" color="text.secondary">
+                  Total Words
+                </Typography>
+                <Typography variant="h6" sx={{ fontWeight: "bold" }}>
+                  1,247
+                </Typography>
               </Box>
 
               <Box sx={{ mb: 2 }}>
-                <Typography variant="body2" color="text.secondary">Average Reading Time</Typography>
-                <Typography variant="h6" sx={{ fontWeight: 'bold' }}>5.2 min</Typography>
+                <Typography variant="body2" color="text.secondary">
+                  Average Reading Time
+                </Typography>
+                <Typography variant="h6" sx={{ fontWeight: "bold" }}>
+                  5.2 min
+                </Typography>
               </Box>
 
               <Box sx={{ mb: 2 }}>
-                <Typography variant="body2" color="text.secondary">Headings Structure</Typography>
+                <Typography variant="body2" color="text.secondary">
+                  Headings Structure
+                </Typography>
                 <Typography variant="body2">H1: 1, H2: 4, H3: 8</Typography>
               </Box>
 
               <Box sx={{ mb: 2 }}>
-                <Typography variant="body2" color="text.secondary">Images</Typography>
-                <Typography variant="body2">12 total, 3 missing alt text</Typography>
+                <Typography variant="body2" color="text.secondary">
+                  Images
+                </Typography>
+                <Typography variant="body2">
+                  12 total, 3 missing alt text
+                </Typography>
               </Box>
 
               <Box>
-                <Typography variant="body2" color="text.secondary">Internal Links</Typography>
+                <Typography variant="body2" color="text.secondary">
+                  Internal Links
+                </Typography>
                 <Typography variant="body2">15 links found</Typography>
               </Box>
             </CardContent>

--- a/src/components/dashboard/OverviewTab.tsx
+++ b/src/components/dashboard/OverviewTab.tsx
@@ -1,8 +1,15 @@
-
-import React from 'react';
-import { Box, Typography, Grid, Card, CardContent, CircularProgress, Alert } from '@mui/material';
-import { TrendingUp, Users, Clock, Star } from 'lucide-react';
-import type { AnalysisResponse } from '@/types/analysis';
+import React from "react";
+import {
+  Box,
+  Typography,
+  Grid,
+  Card,
+  CardContent,
+  CircularProgress,
+  Alert,
+} from "@mui/material";
+import { TrendingUp, Users, Clock, Star } from "lucide-react";
+import type { AnalysisResponse } from "@/types/analysis";
 
 interface OverviewTabProps {
   data: AnalysisResponse | null;
@@ -13,9 +20,18 @@ interface OverviewTabProps {
 const OverviewTab: React.FC<OverviewTabProps> = ({ data, loading, error }) => {
   if (loading) {
     return (
-      <Box sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center', py: 8 }}>
+      <Box
+        sx={{
+          display: "flex",
+          justifyContent: "center",
+          alignItems: "center",
+          py: 8,
+        }}
+      >
         <CircularProgress size={60} />
-        <Typography variant="h6" sx={{ ml: 2 }}>Analyzing website...</Typography>
+        <Typography variant="h6" sx={{ ml: 2 }}>
+          Analyzing website...
+        </Typography>
       </Box>
     );
   }
@@ -38,65 +54,104 @@ const OverviewTab: React.FC<OverviewTabProps> = ({ data, loading, error }) => {
 
   const metrics = [
     {
-      title: 'Overall Score',
+      title: "Overall Score",
       value: `${data.data.overview.overallScore}/100`,
       icon: Star,
-      color: data.data.overview.overallScore >= 80 ? '#4CAF50' : data.data.overview.overallScore >= 60 ? '#FF9800' : '#F44336',
-      description: data.data.overview.overallScore >= 80 ? 'Excellent performance overall' : data.data.overview.overallScore >= 60 ? 'Good, could be improved' : 'Needs improvement'
+      color:
+        data.data.overview.overallScore >= 80
+          ? "#4CAF50"
+          : data.data.overview.overallScore >= 60
+            ? "#FF9800"
+            : "#F44336",
+      description:
+        data.data.overview.overallScore >= 80
+          ? "Excellent performance overall"
+          : data.data.overview.overallScore >= 60
+            ? "Good, could be improved"
+            : "Needs improvement",
     },
     {
-      title: 'Page Load Time',
+      title: "Page Load Time",
       value: data.data.overview.pageLoadTime,
       icon: Clock,
-      color: '#FF9800',
-      description: 'Page loading performance'
+      color: "#FF9800",
+      description: "Page loading performance",
     },
     {
-      title: 'SEO Score',
+      title: "SEO Score",
       value: `${data.data.overview.seoScore}/100`,
       icon: TrendingUp,
-      color: data.data.overview.seoScore >= 80 ? '#4CAF50' : data.data.overview.seoScore >= 60 ? '#FF9800' : '#F44336',
-      description: data.data.overview.seoScore >= 80 ? 'Excellent SEO optimization' : 'SEO could be improved'
+      color:
+        data.data.overview.seoScore >= 80
+          ? "#4CAF50"
+          : data.data.overview.seoScore >= 60
+            ? "#FF9800"
+            : "#F44336",
+      description:
+        data.data.overview.seoScore >= 80
+          ? "Excellent SEO optimization"
+          : "SEO could be improved",
     },
     {
-      title: 'User Experience',
+      title: "User Experience",
       value: `${data.data.overview.userExperienceScore}/100`,
       icon: Users,
-      color: data.data.overview.userExperienceScore >= 80 ? '#4CAF50' : '#2196F3',
-      description: data.data.overview.userExperienceScore >= 80 ? 'Excellent user experience' : 'Good user experience'
-    }
+      color:
+        data.data.overview.userExperienceScore >= 80 ? "#4CAF50" : "#2196F3",
+      description:
+        data.data.overview.userExperienceScore >= 80
+          ? "Excellent user experience"
+          : "Good user experience",
+    },
   ];
 
   return (
     <Box>
-      <Typography variant="h5" gutterBottom sx={{ fontWeight: 'bold', mb: 3 }}>
+      <Typography variant="h5" gutterBottom sx={{ fontWeight: "bold", mb: 3 }}>
         Website Overview - {data.url}
       </Typography>
-      
-      <Grid container spacing={3}>
+
+      <Grid container spacing={3} alignItems="stretch">
         {metrics.map((metric, index) => {
           const IconComponent = metric.icon;
           return (
-            <Grid xs={12} sm={6} md={3} key={index}>
-              <Card sx={{ height: '100%', borderRadius: 2 }}>
+            <Grid
+              item
+              xs={12}
+              sm={6}
+              md={6}
+              lg={6}
+              xl={6}
+              key={index}
+              sx={{ display: "flex" }}
+            >
+              <Card sx={{ height: "100%", borderRadius: 2, flexGrow: 1 }}>
                 <CardContent sx={{ p: 3 }}>
-                  <Box sx={{ display: 'flex', alignItems: 'center', mb: 2 }}>
+                  <Box sx={{ display: "flex", alignItems: "center", mb: 2 }}>
                     <Box
                       sx={{
                         p: 1,
                         borderRadius: 1,
                         backgroundColor: `${metric.color}20`,
                         color: metric.color,
-                        mr: 2
+                        mr: 2,
                       }}
                     >
                       <IconComponent size={24} />
                     </Box>
-                    <Typography variant="h6" component="div" sx={{ fontWeight: 'bold' }}>
+                    <Typography
+                      variant="h6"
+                      component="div"
+                      sx={{ fontWeight: "bold" }}
+                    >
                       {metric.value}
                     </Typography>
                   </Box>
-                  <Typography variant="subtitle1" gutterBottom sx={{ fontWeight: 'medium' }}>
+                  <Typography
+                    variant="subtitle1"
+                    gutterBottom
+                    sx={{ fontWeight: "medium" }}
+                  >
                     {metric.title}
                   </Typography>
                   <Typography variant="body2" color="text.secondary">
@@ -110,17 +165,16 @@ const OverviewTab: React.FC<OverviewTabProps> = ({ data, loading, error }) => {
       </Grid>
 
       <Box sx={{ mt: 4 }}>
-        <Typography variant="h6" gutterBottom sx={{ fontWeight: 'bold' }}>
+        <Typography variant="h6" gutterBottom sx={{ fontWeight: "bold" }}>
           Analysis Summary
         </Typography>
         <Card sx={{ borderRadius: 2 }}>
           <CardContent sx={{ p: 3 }}>
             <Typography variant="body1" paragraph>
-              Analysis completed at {new Date(data.timestamp).toLocaleString()}. 
-              {data.data.overview.overallScore >= 80 ? 
-                ' The page shows excellent performance across most metrics.' :
-                ' The page has room for improvement in several areas.'
-              }
+              Analysis completed at {new Date(data.timestamp).toLocaleString()}.
+              {data.data.overview.overallScore >= 80
+                ? " The page shows excellent performance across most metrics."
+                : " The page has room for improvement in several areas."}
             </Typography>
             <Typography variant="body1" paragraph>
               <strong>Key Findings:</strong>
@@ -133,7 +187,8 @@ const OverviewTab: React.FC<OverviewTabProps> = ({ data, loading, error }) => {
                 Page Load Time: {data.data.overview.pageLoadTime}
               </Typography>
               <Typography component="li" variant="body2" sx={{ mb: 1 }}>
-                User Experience Score: {data.data.overview.userExperienceScore}/100
+                User Experience Score: {data.data.overview.userExperienceScore}
+                /100
               </Typography>
             </Box>
           </CardContent>

--- a/src/components/dashboard/PerformanceTab.tsx
+++ b/src/components/dashboard/PerformanceTab.tsx
@@ -1,10 +1,19 @@
-
-import React from 'react';
-import { Box, Typography, Grid, Card, CardContent, LinearProgress, CircularProgress, Alert, Chip } from '@mui/material';
-import { ChartContainer, ChartTooltip, ChartTooltipContent } from '../ui/chart';
-import { BarChart, Bar, XAxis, YAxis, ResponsiveContainer } from 'recharts';
-import { Shield, Smartphone, Zap } from 'lucide-react';
-import type { AnalysisResponse } from '@/types/analysis';
+import React from "react";
+import {
+  Box,
+  Typography,
+  Grid,
+  Card,
+  CardContent,
+  LinearProgress,
+  CircularProgress,
+  Alert,
+  Chip,
+} from "@mui/material";
+import { ChartContainer, ChartTooltip, ChartTooltipContent } from "../ui/chart";
+import { BarChart, Bar, XAxis, YAxis, ResponsiveContainer } from "recharts";
+import { Shield, Smartphone, Zap } from "lucide-react";
+import type { AnalysisResponse } from "@/types/analysis";
 
 interface PerformanceTabProps {
   data: AnalysisResponse | null;
@@ -12,12 +21,25 @@ interface PerformanceTabProps {
   error: string | null;
 }
 
-const PerformanceTab: React.FC<PerformanceTabProps> = ({ data, loading, error }) => {
+const PerformanceTab: React.FC<PerformanceTabProps> = ({
+  data,
+  loading,
+  error,
+}) => {
   if (loading) {
     return (
-      <Box sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center', py: 8 }}>
+      <Box
+        sx={{
+          display: "flex",
+          justifyContent: "center",
+          alignItems: "center",
+          py: 8,
+        }}
+      >
         <CircularProgress size={60} />
-        <Typography variant="h6" sx={{ ml: 2 }}>Analyzing performance & security...</Typography>
+        <Typography variant="h6" sx={{ ml: 2 }}>
+          Analyzing performance & security...
+        </Typography>
       </Box>
     );
   }
@@ -40,53 +62,85 @@ const PerformanceTab: React.FC<PerformanceTabProps> = ({ data, loading, error })
 
   const { performance } = data.data;
   const chartConfig = {
-    value: { label: 'Your Site', color: '#2196F3' },
-    benchmark: { label: 'Industry Average', color: '#E0E0E0' }
+    value: { label: "Your Site", color: "#2196F3" },
+    benchmark: { label: "Industry Average", color: "#E0E0E0" },
   };
 
   const getScoreColor = (score: number) => {
-    if (score >= 90) return '#4CAF50';
-    if (score >= 70) return '#FF9800';
-    return '#F44336';
+    if (score >= 90) return "#4CAF50";
+    if (score >= 70) return "#FF9800";
+    return "#F44336";
   };
 
   return (
     <Box>
-      <Typography variant="h5" gutterBottom sx={{ fontWeight: 'bold', mb: 3 }}>
+      <Typography variant="h5" gutterBottom sx={{ fontWeight: "bold", mb: 3 }}>
         Performance & Security Analysis
       </Typography>
 
       {/* Performance Score Section */}
       <Grid container spacing={3} sx={{ mb: 4 }}>
-        <Grid xs={12} md={4}>
+        <Grid item xs={12} md={4}>
           <Card sx={{ borderRadius: 2 }}>
-            <CardContent sx={{ p: 3, textAlign: 'center' }}>
-              <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'center', mb: 2 }}>
+            <CardContent sx={{ p: 3, textAlign: "center" }}>
+              <Box
+                sx={{
+                  display: "flex",
+                  alignItems: "center",
+                  justifyContent: "center",
+                  mb: 2,
+                }}
+              >
                 <Zap size={24} color="#FF6B35" style={{ marginRight: 8 }} />
-                <Typography variant="h6" sx={{ fontWeight: 'bold' }}>
+                <Typography variant="h6" sx={{ fontWeight: "bold" }}>
                   Performance Score
                 </Typography>
               </Box>
-              <Typography variant="h2" sx={{ fontWeight: 'bold', color: getScoreColor(performance.performanceScore) }}>
+              <Typography
+                variant="h2"
+                sx={{
+                  fontWeight: "bold",
+                  color: getScoreColor(performance.performanceScore),
+                }}
+              >
                 {performance.performanceScore}
               </Typography>
               <Typography variant="body2" color="text.primary">
-                {performance.performanceScore >= 90 ? 'Excellent' : performance.performanceScore >= 70 ? 'Good' : 'Needs Improvement'} Performance
+                {performance.performanceScore >= 90
+                  ? "Excellent"
+                  : performance.performanceScore >= 70
+                    ? "Good"
+                    : "Needs Improvement"}{" "}
+                Performance
               </Typography>
             </CardContent>
           </Card>
         </Grid>
 
-        <Grid xs={12} md={4}>
+        <Grid item xs={12} md={4}>
           <Card sx={{ borderRadius: 2 }}>
-            <CardContent sx={{ p: 3, textAlign: 'center' }}>
-              <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'center', mb: 2 }}>
-                <Smartphone size={24} color="#FF6B35" style={{ marginRight: 8 }} />
-                <Typography variant="h6" sx={{ fontWeight: 'bold' }}>
+            <CardContent sx={{ p: 3, textAlign: "center" }}>
+              <Box
+                sx={{
+                  display: "flex",
+                  alignItems: "center",
+                  justifyContent: "center",
+                  mb: 2,
+                }}
+              >
+                <Smartphone
+                  size={24}
+                  color="#FF6B35"
+                  style={{ marginRight: 8 }}
+                />
+                <Typography variant="h6" sx={{ fontWeight: "bold" }}>
                   Mobile Responsiveness
                 </Typography>
               </Box>
-              <Typography variant="h3" sx={{ fontWeight: 'bold', color: '#4CAF50' }}>
+              <Typography
+                variant="h3"
+                sx={{ fontWeight: "bold", color: "#4CAF50" }}
+              >
                 —
               </Typography>
               <Typography variant="body2" color="text.secondary">
@@ -96,16 +150,26 @@ const PerformanceTab: React.FC<PerformanceTabProps> = ({ data, loading, error })
           </Card>
         </Grid>
 
-        <Grid xs={12} md={4}>
+        <Grid item xs={12} md={4}>
           <Card sx={{ borderRadius: 2 }}>
-            <CardContent sx={{ p: 3, textAlign: 'center' }}>
-              <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'center', mb: 2 }}>
+            <CardContent sx={{ p: 3, textAlign: "center" }}>
+              <Box
+                sx={{
+                  display: "flex",
+                  alignItems: "center",
+                  justifyContent: "center",
+                  mb: 2,
+                }}
+              >
                 <Shield size={24} color="#FF6B35" style={{ marginRight: 8 }} />
-                <Typography variant="h6" sx={{ fontWeight: 'bold' }}>
+                <Typography variant="h6" sx={{ fontWeight: "bold" }}>
                   Security Score
                 </Typography>
               </Box>
-              <Typography variant="h3" sx={{ fontWeight: 'bold', color: '#4CAF50' }}>
+              <Typography
+                variant="h3"
+                sx={{ fontWeight: "bold", color: "#4CAF50" }}
+              >
                 —
               </Typography>
               <Typography variant="body2" color="text.secondary">
@@ -118,14 +182,17 @@ const PerformanceTab: React.FC<PerformanceTabProps> = ({ data, loading, error })
 
       {/* Core Web Vitals Section */}
       <Grid container spacing={3} sx={{ mb: 4 }}>
-        <Grid xs={12} md={8}>
-          <Card sx={{ borderRadius: 2, height: '400px' }}>
-            <CardContent sx={{ p: 3, height: '100%' }}>
-              <Typography variant="h6" gutterBottom sx={{ fontWeight: 'bold' }}>
+        <Grid item xs={12} md={8}>
+          <Card sx={{ borderRadius: 2, height: "400px" }}>
+            <CardContent sx={{ p: 3, height: "100%" }}>
+              <Typography variant="h6" gutterBottom sx={{ fontWeight: "bold" }}>
                 Core Web Vitals
               </Typography>
               <ChartContainer config={chartConfig} className="h-80">
-                <BarChart data={performance.coreWebVitals} margin={{ top: 20, right: 30, left: 20, bottom: 5 }}>
+                <BarChart
+                  data={performance.coreWebVitals}
+                  margin={{ top: 20, right: 30, left: 20, bottom: 5 }}
+                >
                   <XAxis dataKey="name" tick={{ fontSize: 12 }} />
                   <YAxis />
                   <ChartTooltip content={<ChartTooltipContent />} />
@@ -137,21 +204,34 @@ const PerformanceTab: React.FC<PerformanceTabProps> = ({ data, loading, error })
           </Card>
         </Grid>
 
-        <Grid xs={12} md={4}>
+        <Grid item xs={12} md={4}>
           <Card sx={{ borderRadius: 2 }}>
             <CardContent sx={{ p: 3 }}>
-              <Typography variant="h6" gutterBottom sx={{ fontWeight: 'bold' }}>
+              <Typography variant="h6" gutterBottom sx={{ fontWeight: "bold" }}>
                 Speed Index
               </Typography>
               <Box sx={{ mb: 2 }}>
-                <Box sx={{ display: 'flex', justifyContent: 'space-between', mb: 1 }}>
+                <Box
+                  sx={{
+                    display: "flex",
+                    justifyContent: "space-between",
+                    mb: 1,
+                  }}
+                >
                   <Typography variant="body2">Loading Speed</Typography>
-                  <Typography variant="body2">{performance.performanceScore}%</Typography>
+                  <Typography variant="body2">
+                    {performance.performanceScore}%
+                  </Typography>
                 </Box>
-                <LinearProgress variant="determinate" value={performance.performanceScore} sx={{ height: 8, borderRadius: 4 }} />
+                <LinearProgress
+                  variant="determinate"
+                  value={performance.performanceScore}
+                  sx={{ height: 8, borderRadius: 4 }}
+                />
               </Box>
               <Typography variant="body2" color="text.secondary">
-                Your page loads faster than {performance.performanceScore}% of websites
+                Your page loads faster than {performance.performanceScore}% of
+                websites
               </Typography>
             </CardContent>
           </Card>
@@ -162,27 +242,29 @@ const PerformanceTab: React.FC<PerformanceTabProps> = ({ data, loading, error })
       <Box sx={{ mb: 4 }}>
         <Card sx={{ borderRadius: 2 }}>
           <CardContent sx={{ p: 3 }}>
-            <Typography variant="h6" gutterBottom sx={{ fontWeight: 'bold' }}>
+            <Typography variant="h6" gutterBottom sx={{ fontWeight: "bold" }}>
               Security Headers Analysis
             </Typography>
             <Grid container spacing={2}>
               {Object.entries(data.securityHeaders).map(([key, value]) => (
-                <Grid xs={12} sm={6} md={4} key={key}>
-                  <Box sx={{ 
-                    p: 2, 
-                    border: '1px solid #E0E0E0',
-                    borderRadius: 1,
-                    display: 'flex',
-                    justifyContent: 'space-between',
-                    alignItems: 'center'
-                  }}>
-                    <Typography variant="body2" sx={{ fontWeight: 'medium' }}>
+                <Grid item xs={12} sm={6} md={4} key={key}>
+                  <Box
+                    sx={{
+                      p: 2,
+                      border: "1px solid #E0E0E0",
+                      borderRadius: 1,
+                      display: "flex",
+                      justifyContent: "space-between",
+                      alignItems: "center",
+                    }}
+                  >
+                    <Typography variant="body2" sx={{ fontWeight: "medium" }}>
                       {key.toUpperCase()}
                     </Typography>
-                    <Chip 
-                      label={value ? 'Present' : 'Missing'} 
-                      color={value ? 'success' : 'error'} 
-                      size="small" 
+                    <Chip
+                      label={value ? "Present" : "Missing"}
+                      color={value ? "success" : "error"}
+                      size="small"
                       variant="outlined"
                     />
                   </Box>
@@ -197,26 +279,44 @@ const PerformanceTab: React.FC<PerformanceTabProps> = ({ data, loading, error })
       <Box sx={{ mt: 3 }}>
         <Card sx={{ borderRadius: 2 }}>
           <CardContent sx={{ p: 3 }}>
-            <Typography variant="h6" gutterBottom sx={{ fontWeight: 'bold' }}>
+            <Typography variant="h6" gutterBottom sx={{ fontWeight: "bold" }}>
               Performance Recommendations
             </Typography>
             <Grid container spacing={2}>
               {performance.recommendations.map((rec, index) => (
-                <Grid xs={12} md={6} key={index}>
-                  <Box sx={{ 
-                    p: 2, 
-                    backgroundColor: rec.type === 'warning' ? '#FFF3E0' : rec.type === 'error' ? '#FFEBEE' : '#E8F5E8', 
-                    borderRadius: 1, 
-                    mb: 2 
-                  }}>
-                    <Typography variant="subtitle2" sx={{ 
-                      fontWeight: 'bold', 
-                      color: rec.type === 'warning' ? '#E65100' : rec.type === 'error' ? '#C62828' : '#2E7D32',
-                      mb: 1
-                    }}>
+                <Grid item xs={12} md={6} key={index}>
+                  <Box
+                    sx={{
+                      p: 2,
+                      backgroundColor:
+                        rec.type === "warning"
+                          ? "#FFF3E0"
+                          : rec.type === "error"
+                            ? "#FFEBEE"
+                            : "#E8F5E8",
+                      borderRadius: 1,
+                      mb: 2,
+                    }}
+                  >
+                    <Typography
+                      variant="subtitle2"
+                      sx={{
+                        fontWeight: "bold",
+                        color:
+                          rec.type === "warning"
+                            ? "#E65100"
+                            : rec.type === "error"
+                              ? "#C62828"
+                              : "#2E7D32",
+                        mb: 1,
+                      }}
+                    >
                       {rec.title}
                     </Typography>
-                    <Typography variant="body2" sx={{ color: 'rgba(0, 0, 0, 0.87)' }}>
+                    <Typography
+                      variant="body2"
+                      sx={{ color: "rgba(0, 0, 0, 0.87)" }}
+                    >
                       {rec.description}
                     </Typography>
                   </Box>

--- a/src/components/dashboard/SEOAnalysisTab.tsx
+++ b/src/components/dashboard/SEOAnalysisTab.tsx
@@ -1,8 +1,16 @@
-
-import React from 'react';
-import { Box, Typography, Grid, Card, CardContent, Chip, CircularProgress, Alert } from '@mui/material';
-import { CheckCircle, AlertCircle, XCircle } from 'lucide-react';
-import type { AnalysisResponse } from '@/types/analysis';
+import React from "react";
+import {
+  Box,
+  Typography,
+  Grid,
+  Card,
+  CardContent,
+  Chip,
+  CircularProgress,
+  Alert,
+} from "@mui/material";
+import { CheckCircle, AlertCircle, XCircle } from "lucide-react";
+import type { AnalysisResponse } from "@/types/analysis";
 
 interface SEOAnalysisTabProps {
   data: AnalysisResponse | null;
@@ -10,12 +18,25 @@ interface SEOAnalysisTabProps {
   error: string | null;
 }
 
-const SEOAnalysisTab: React.FC<SEOAnalysisTabProps> = ({ data, loading, error }) => {
+const SEOAnalysisTab: React.FC<SEOAnalysisTabProps> = ({
+  data,
+  loading,
+  error,
+}) => {
   if (loading) {
     return (
-      <Box sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center', py: 8 }}>
+      <Box
+        sx={{
+          display: "flex",
+          justifyContent: "center",
+          alignItems: "center",
+          py: 8,
+        }}
+      >
         <CircularProgress size={60} />
-        <Typography variant="h6" sx={{ ml: 2 }}>Analyzing SEO...</Typography>
+        <Typography variant="h6" sx={{ ml: 2 }}>
+          Analyzing SEO...
+        </Typography>
       </Box>
     );
   }
@@ -40,11 +61,11 @@ const SEOAnalysisTab: React.FC<SEOAnalysisTabProps> = ({ data, loading, error })
 
   const getStatusIcon = (status: string) => {
     switch (status) {
-      case 'good':
+      case "good":
         return <CheckCircle size={20} color="#4CAF50" />;
-      case 'warning':
+      case "warning":
         return <AlertCircle size={20} color="#FF9800" />;
-      case 'error':
+      case "error":
         return <XCircle size={20} color="#F44336" />;
       default:
         return <CheckCircle size={20} color="#4CAF50" />;
@@ -53,41 +74,41 @@ const SEOAnalysisTab: React.FC<SEOAnalysisTabProps> = ({ data, loading, error })
 
   const getStatusColor = (status: string) => {
     switch (status) {
-      case 'good':
-        return 'success';
-      case 'warning':
-        return 'warning';
-      case 'error':
-        return 'error';
+      case "good":
+        return "success";
+      case "warning":
+        return "warning";
+      case "error":
+        return "error";
       default:
-        return 'success';
+        return "success";
     }
   };
 
   const getPriorityColor = (priority: string) => {
     switch (priority) {
-      case 'high':
-        return '#F44336';
-      case 'medium':
-        return '#FF9800';
-      case 'low':
-        return '#4CAF50';
+      case "high":
+        return "#F44336";
+      case "medium":
+        return "#FF9800";
+      case "low":
+        return "#4CAF50";
       default:
-        return '#757575';
+        return "#757575";
     }
   };
 
   return (
     <Box>
-      <Typography variant="h5" gutterBottom sx={{ fontWeight: 'bold', mb: 3 }}>
+      <Typography variant="h5" gutterBottom sx={{ fontWeight: "bold", mb: 3 }}>
         SEO Analysis
       </Typography>
 
       <Grid container spacing={3}>
-        <Grid xs={12} md={8}>
+        <Grid item xs={12} md={8}>
           <Card sx={{ borderRadius: 2 }}>
             <CardContent sx={{ p: 3 }}>
-              <Typography variant="h6" gutterBottom sx={{ fontWeight: 'bold' }}>
+              <Typography variant="h6" gutterBottom sx={{ fontWeight: "bold" }}>
                 SEO Checklist
               </Typography>
               <Box>
@@ -95,17 +116,21 @@ const SEOAnalysisTab: React.FC<SEOAnalysisTabProps> = ({ data, loading, error })
                   <Box
                     key={index}
                     sx={{
-                      display: 'flex',
-                      alignItems: 'center',
+                      display: "flex",
+                      alignItems: "center",
                       p: 2,
-                      borderBottom: index < seo.checks.length - 1 ? '1px solid #E0E0E0' : 'none',
+                      borderBottom:
+                        index < seo.checks.length - 1
+                          ? "1px solid #E0E0E0"
+                          : "none",
                     }}
                   >
-                    <Box sx={{ mr: 2 }}>
-                      {getStatusIcon(check.status)}
-                    </Box>
+                    <Box sx={{ mr: 2 }}>{getStatusIcon(check.status)}</Box>
                     <Box sx={{ flexGrow: 1 }}>
-                      <Typography variant="subtitle1" sx={{ fontWeight: 'medium' }}>
+                      <Typography
+                        variant="subtitle1"
+                        sx={{ fontWeight: "medium" }}
+                      >
                         {check.name}
                       </Typography>
                       <Typography variant="body2" color="text.secondary">
@@ -125,47 +150,84 @@ const SEOAnalysisTab: React.FC<SEOAnalysisTabProps> = ({ data, loading, error })
           </Card>
         </Grid>
 
-        <Grid xs={12} md={4}>
+        <Grid item xs={12} md={4}>
           <Card sx={{ borderRadius: 2, mb: 2 }}>
-            <CardContent sx={{ p: 3, textAlign: 'center' }}>
-              <Typography variant="h6" gutterBottom sx={{ fontWeight: 'bold' }}>
+            <CardContent sx={{ p: 3, textAlign: "center" }}>
+              <Typography variant="h6" gutterBottom sx={{ fontWeight: "bold" }}>
                 SEO Score
               </Typography>
-              <Typography variant="h2" sx={{ 
-                fontWeight: 'bold', 
-                color: seo.score >= 80 ? '#4CAF50' : seo.score >= 60 ? '#FF9800' : '#F44336',
-                mb: 1 
-              }}>
+              <Typography
+                variant="h2"
+                sx={{
+                  fontWeight: "bold",
+                  color:
+                    seo.score >= 80
+                      ? "#4CAF50"
+                      : seo.score >= 60
+                        ? "#FF9800"
+                        : "#F44336",
+                  mb: 1,
+                }}
+              >
                 {seo.score}
               </Typography>
               <Typography variant="body2" color="text.secondary">
-                {seo.score >= 80 ? 'Excellent SEO' : seo.score >= 60 ? 'Good SEO' : 'Needs Improvement'}
+                {seo.score >= 80
+                  ? "Excellent SEO"
+                  : seo.score >= 60
+                    ? "Good SEO"
+                    : "Needs Improvement"}
               </Typography>
             </CardContent>
           </Card>
 
           <Card sx={{ borderRadius: 2 }}>
             <CardContent sx={{ p: 3 }}>
-              <Typography variant="h6" gutterBottom sx={{ fontWeight: 'bold' }}>
+              <Typography variant="h6" gutterBottom sx={{ fontWeight: "bold" }}>
                 Analysis Status
               </Typography>
               <Box sx={{ mb: 2 }}>
-                <Box sx={{ display: 'flex', justifyContent: 'space-between', mb: 1 }}>
+                <Box
+                  sx={{
+                    display: "flex",
+                    justifyContent: "space-between",
+                    mb: 1,
+                  }}
+                >
                   <Typography variant="body2">Checks Passed</Typography>
-                  <Typography variant="body2" sx={{ fontWeight: 'bold' }}>
-                    {seo.checks.filter(c => c.status === 'good').length}/{seo.checks.length}
+                  <Typography variant="body2" sx={{ fontWeight: "bold" }}>
+                    {seo.checks.filter((c) => c.status === "good").length}/
+                    {seo.checks.length}
                   </Typography>
                 </Box>
-                <Box sx={{ display: 'flex', justifyContent: 'space-between', mb: 1 }}>
+                <Box
+                  sx={{
+                    display: "flex",
+                    justifyContent: "space-between",
+                    mb: 1,
+                  }}
+                >
                   <Typography variant="body2">Warnings</Typography>
-                  <Typography variant="body2" sx={{ fontWeight: 'bold', color: '#FF9800' }}>
-                    {seo.checks.filter(c => c.status === 'warning').length}
+                  <Typography
+                    variant="body2"
+                    sx={{ fontWeight: "bold", color: "#FF9800" }}
+                  >
+                    {seo.checks.filter((c) => c.status === "warning").length}
                   </Typography>
                 </Box>
-                <Box sx={{ display: 'flex', justifyContent: 'space-between', mb: 1 }}>
+                <Box
+                  sx={{
+                    display: "flex",
+                    justifyContent: "space-between",
+                    mb: 1,
+                  }}
+                >
                   <Typography variant="body2">Errors</Typography>
-                  <Typography variant="body2" sx={{ fontWeight: 'bold', color: '#F44336' }}>
-                    {seo.checks.filter(c => c.status === 'error').length}
+                  <Typography
+                    variant="body2"
+                    sx={{ fontWeight: "bold", color: "#F44336" }}
+                  >
+                    {seo.checks.filter((c) => c.status === "error").length}
                   </Typography>
                 </Box>
               </Box>
@@ -177,37 +239,45 @@ const SEOAnalysisTab: React.FC<SEOAnalysisTabProps> = ({ data, loading, error })
       <Box sx={{ mt: 3 }}>
         <Card sx={{ borderRadius: 2 }}>
           <CardContent sx={{ p: 3 }}>
-            <Typography variant="h6" gutterBottom sx={{ fontWeight: 'bold' }}>
+            <Typography variant="h6" gutterBottom sx={{ fontWeight: "bold" }}>
               SEO Recommendations
             </Typography>
             <Grid container spacing={2}>
               {seo.recommendations.map((rec, index) => (
-                <Grid xs={12} md={6} key={index}>
-                  <Box sx={{ 
-                    p: 2, 
-                    border: `1px solid ${getPriorityColor(rec.priority)}`,
-                    borderRadius: 1,
-                    backgroundColor: `${getPriorityColor(rec.priority)}10`
-                  }}>
-                    <Box sx={{ display: 'flex', alignItems: 'center', mb: 1 }}>
-                      <Typography variant="subtitle2" sx={{ 
-                        fontWeight: 'bold', 
-                        color: getPriorityColor(rec.priority),
-                        mr: 1
-                      }}>
+                <Grid item xs={12} md={6} key={index}>
+                  <Box
+                    sx={{
+                      p: 2,
+                      border: `1px solid ${getPriorityColor(rec.priority)}`,
+                      borderRadius: 1,
+                      backgroundColor: `${getPriorityColor(rec.priority)}10`,
+                    }}
+                  >
+                    <Box sx={{ display: "flex", alignItems: "center", mb: 1 }}>
+                      <Typography
+                        variant="subtitle2"
+                        sx={{
+                          fontWeight: "bold",
+                          color: getPriorityColor(rec.priority),
+                          mr: 1,
+                        }}
+                      >
                         {rec.title}
                       </Typography>
-                      <Chip 
-                        label={rec.priority} 
-                        size="small" 
-                        sx={{ 
+                      <Chip
+                        label={rec.priority}
+                        size="small"
+                        sx={{
                           backgroundColor: getPriorityColor(rec.priority),
-                          color: 'white',
-                          fontSize: '0.7rem'
+                          color: "white",
+                          fontSize: "0.7rem",
                         }}
                       />
                     </Box>
-                    <Typography variant="body2" sx={{ color: 'rgba(0, 0, 0, 0.87)' }}>
+                    <Typography
+                      variant="body2"
+                      sx={{ color: "rgba(0, 0, 0, 0.87)" }}
+                    >
                       {rec.description}
                     </Typography>
                   </Box>

--- a/src/components/dashboard/TechTab.tsx
+++ b/src/components/dashboard/TechTab.tsx
@@ -1,9 +1,34 @@
-
-import React from 'react';
-import { Box, Typography, Grid, Card, CardContent, Chip, CircularProgress, Alert } from '@mui/material';
-import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '../ui/table';
-import { Shield, Globe, Server, Database, Code, Layers, Zap, Activity, BarChart } from 'lucide-react';
-import type { AnalysisResponse } from '@/types/analysis';
+import React from "react";
+import {
+  Box,
+  Typography,
+  Grid,
+  Card,
+  CardContent,
+  Chip,
+  CircularProgress,
+  Alert,
+} from "@mui/material";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "../ui/table";
+import {
+  Shield,
+  Globe,
+  Server,
+  Database,
+  Code,
+  Layers,
+  Zap,
+  Activity,
+  BarChart,
+} from "lucide-react";
+import type { AnalysisResponse } from "@/types/analysis";
 
 interface TechTabProps {
   data: AnalysisResponse | null;
@@ -14,9 +39,18 @@ interface TechTabProps {
 const TechTab: React.FC<TechTabProps> = ({ data, loading, error }) => {
   if (loading) {
     return (
-      <Box sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center', py: 8 }}>
+      <Box
+        sx={{
+          display: "flex",
+          justifyContent: "center",
+          alignItems: "center",
+          py: 8,
+        }}
+      >
         <CircularProgress size={60} />
-        <Typography variant="h6" sx={{ ml: 2 }}>Analyzing tech stack...</Typography>
+        <Typography variant="h6" sx={{ ml: 2 }}>
+          Analyzing tech stack...
+        </Typography>
       </Box>
     );
   }
@@ -40,57 +74,57 @@ const TechTab: React.FC<TechTabProps> = ({ data, loading, error }) => {
   const { technical } = data.data;
 
   const iconMap: { [key: string]: any } = {
-    'Frontend Framework': Code,
-    'JavaScript frameworks': Code,
-    'Framework': Code,
-    'Build Tool': Zap,
-    'Styling': Layers,
-    'CSS frameworks': Layers,
-    'CSS Framework': Layers,
-    'Backend': Server,
-    'Database': Database,
-    'Databases': Database,
-    'Hosting': Globe,
-    'Library': Code,
-    'JavaScript libraries': Code,
-    'Markup': Code,
-    'Web servers': Server,
-    'Analytics': BarChart,
-    'Tag managers': Activity,
-    'CDN': Globe,
-    'Content delivery networks': Globe,
-    'Widgets': Code,
-    'Unknown': Code,
-    'default': Server
+    "Frontend Framework": Code,
+    "JavaScript frameworks": Code,
+    Framework: Code,
+    "Build Tool": Zap,
+    Styling: Layers,
+    "CSS frameworks": Layers,
+    "CSS Framework": Layers,
+    Backend: Server,
+    Database: Database,
+    Databases: Database,
+    Hosting: Globe,
+    Library: Code,
+    "JavaScript libraries": Code,
+    Markup: Code,
+    "Web servers": Server,
+    Analytics: BarChart,
+    "Tag managers": Activity,
+    CDN: Globe,
+    "Content delivery networks": Globe,
+    Widgets: Code,
+    Unknown: Code,
+    default: Server,
   };
 
   const getIcon = (category: string) => {
-    return iconMap[category] || iconMap['default'];
+    return iconMap[category] || iconMap["default"];
   };
 
   const getSeverityColor = (severity: string) => {
     switch (severity.toLowerCase()) {
-      case 'high':
-        return '#F44336';
-      case 'medium':
-        return '#FF9800';
-      case 'low':
-        return '#4CAF50';
+      case "high":
+        return "#F44336";
+      case "medium":
+        return "#FF9800";
+      case "low":
+        return "#4CAF50";
       default:
-        return '#757575';
+        return "#757575";
     }
   };
 
   const getHealthGradeColor = (grade: string) => {
-    if (grade.startsWith('A')) return '#4CAF50';
-    if (grade.startsWith('B')) return '#8BC34A';
-    if (grade.startsWith('C')) return '#FF9800';
-    return '#F44336';
+    if (grade.startsWith("A")) return "#4CAF50";
+    if (grade.startsWith("B")) return "#8BC34A";
+    if (grade.startsWith("C")) return "#FF9800";
+    return "#F44336";
   };
 
   return (
     <Box>
-      <Typography variant="h5" gutterBottom sx={{ fontWeight: 'bold', mb: 3 }}>
+      <Typography variant="h5" gutterBottom sx={{ fontWeight: "bold", mb: 3 }}>
         Technical Analysis
       </Typography>
 
@@ -98,35 +132,56 @@ const TechTab: React.FC<TechTabProps> = ({ data, loading, error }) => {
       <Card sx={{ borderRadius: 2, mb: 3 }}>
         <CardContent sx={{ p: 3 }}>
           <Box sx={{ mb: 3 }}>
-            <Typography variant="h6" sx={{ fontWeight: 'bold', display: 'inline' }}>
+            <Typography
+              variant="h6"
+              sx={{ fontWeight: "bold", display: "inline" }}
+            >
               Tech Stack
             </Typography>
-            <Typography variant="body2" sx={{ fontSize: '0.75rem', fontWeight: 'normal', color: 'text.secondary', ml: 1, display: 'inline' }}>
+            <Typography
+              variant="body2"
+              sx={{
+                fontSize: "0.75rem",
+                fontWeight: "normal",
+                color: "text.secondary",
+                ml: 1,
+                display: "inline",
+              }}
+            >
               (Powered by Wappalyzer)
             </Typography>
           </Box>
-          
+
           <Grid container spacing={2}>
             {technical.techStack.map((tech, index) => {
               const IconComponent = getIcon(tech.category);
               return (
-                <Grid xs={12} sm={6} md={4} key={index}>
-                  <Box sx={{
-                    p: 2,
-                    border: '1px solid #E0E0E0',
-                    borderRadius: 2,
-                    display: 'flex',
-                    alignItems: 'center',
-                    '&:hover': {
-                      backgroundColor: 'rgba(255, 107, 53, 0.05)'
-                    }
-                  }}>
-                    <IconComponent size={20} color="#FF6B35" style={{ marginRight: 12 }} />
+                <Grid item xs={12} sm={6} md={4} key={index}>
+                  <Box
+                    sx={{
+                      p: 2,
+                      border: "1px solid #E0E0E0",
+                      borderRadius: 2,
+                      display: "flex",
+                      alignItems: "center",
+                      "&:hover": {
+                        backgroundColor: "rgba(255, 107, 53, 0.05)",
+                      },
+                    }}
+                  >
+                    <IconComponent
+                      size={20}
+                      color="#FF6B35"
+                      style={{ marginRight: 12 }}
+                    />
                     <Box>
                       <Typography variant="body2" color="text.secondary">
                         {tech.category}
                       </Typography>
-                      <Typography variant="subtitle2" sx={{ fontWeight: 'bold' }}>
+                      <Typography
+                        variant="subtitle2"
+                        sx={{ fontWeight: "bold" }}
+                      >
                         {tech.technology}
                       </Typography>
                     </Box>
@@ -142,43 +197,47 @@ const TechTab: React.FC<TechTabProps> = ({ data, loading, error }) => {
       {data.data.adTags && (
         <Card sx={{ borderRadius: 2, mb: 3 }}>
           <CardContent sx={{ p: 3 }}>
-            <Typography variant="h6" gutterBottom sx={{ fontWeight: 'bold', mb: 3 }}>
+            <Typography
+              variant="h6"
+              gutterBottom
+              sx={{ fontWeight: "bold", mb: 3 }}
+            >
               Detected Ad Tags
             </Typography>
             <Grid container spacing={2}>
               {[
-                { label: 'Google GAM/GPT', key: 'hasGAM' },
-                { label: 'AdSense/DFP', key: 'hasAdSense' },
-                { label: 'Prebid.js', key: 'hasPrebid' },
-                { label: 'Amazon Publisher Services', key: 'hasAPS' },
-                { label: 'Index Exchange', key: 'hasIX' },
-                { label: 'AppNexus/Xandr', key: 'hasANX' },
-                { label: 'OpenX', key: 'hasOpenX' },
-                { label: 'Rubicon', key: 'hasRubicon' },
-                { label: 'PubMatic', key: 'hasPubMatic' },
-                { label: 'VPAID/VMAP/IMA', key: 'hasVPAID' },
-                { label: 'Criteo', key: 'hasCriteo' },
-                { label: 'Taboola', key: 'hasTaboola' },
-                { label: 'Outbrain', key: 'hasOutbrain' },
-                { label: 'Sharethrough', key: 'hasSharethrough' },
-                { label: 'Teads', key: 'hasTeads' },
-                { label: 'Moat', key: 'hasMoat' },
-                { label: 'DoubleVerify', key: 'hasDV' },
-                { label: 'Integral Ad Science', key: 'hasIAS' }
+                { label: "Google GAM/GPT", key: "hasGAM" },
+                { label: "AdSense/DFP", key: "hasAdSense" },
+                { label: "Prebid.js", key: "hasPrebid" },
+                { label: "Amazon Publisher Services", key: "hasAPS" },
+                { label: "Index Exchange", key: "hasIX" },
+                { label: "AppNexus/Xandr", key: "hasANX" },
+                { label: "OpenX", key: "hasOpenX" },
+                { label: "Rubicon", key: "hasRubicon" },
+                { label: "PubMatic", key: "hasPubMatic" },
+                { label: "VPAID/VMAP/IMA", key: "hasVPAID" },
+                { label: "Criteo", key: "hasCriteo" },
+                { label: "Taboola", key: "hasTaboola" },
+                { label: "Outbrain", key: "hasOutbrain" },
+                { label: "Sharethrough", key: "hasSharethrough" },
+                { label: "Teads", key: "hasTeads" },
+                { label: "Moat", key: "hasMoat" },
+                { label: "DoubleVerify", key: "hasDV" },
+                { label: "Integral Ad Science", key: "hasIAS" },
               ].map(({ label, key }) => (
-                <Grid xs={6} sm={6} md={4} key={key}>
+                <Grid item xs={6} sm={6} md={4} key={key}>
                   <Chip
                     label={label}
-                    color={data.data.adTags[key] ? 'success' : 'default'}
-                    variant={data.data.adTags[key] ? 'filled' : 'outlined'}
+                    color={data.data.adTags[key] ? "success" : "default"}
+                    variant={data.data.adTags[key] ? "filled" : "outlined"}
                     size="small"
                     sx={{
-                      width: '100%',
-                      justifyContent: 'flex-start',
-                      '& .MuiChip-label': {
-                        width: '100%',
-                        textAlign: 'left'
-                      }
+                      width: "100%",
+                      justifyContent: "flex-start",
+                      "& .MuiChip-label": {
+                        width: "100%",
+                        textAlign: "left",
+                      },
                     }}
                   />
                 </Grid>
@@ -191,35 +250,45 @@ const TechTab: React.FC<TechTabProps> = ({ data, loading, error }) => {
       {/* Detected Social Tags Section */}
       <Card sx={{ borderRadius: 2, mb: 3 }}>
         <CardContent sx={{ p: 3 }}>
-          <Typography variant="h6" gutterBottom sx={{ fontWeight: 'bold', mb: 3 }}>
+          <Typography
+            variant="h6"
+            gutterBottom
+            sx={{ fontWeight: "bold", mb: 3 }}
+          >
             Detected Social Tags
           </Typography>
           <Grid container spacing={2}>
-            <Grid xs={12} sm={6} md={4}>
+            <Grid item xs={12} sm={6} md={4}>
               <Chip
                 label="Open Graph Meta Tags"
-                color={technical.social?.hasOpenGraph ? 'success' : 'default'}
-                variant={technical.social?.hasOpenGraph ? 'filled' : 'outlined'}
+                color={technical.social?.hasOpenGraph ? "success" : "default"}
+                variant={technical.social?.hasOpenGraph ? "filled" : "outlined"}
                 size="small"
-                sx={{ width: '100%' }}
+                sx={{ width: "100%" }}
               />
             </Grid>
-            <Grid xs={12} sm={6} md={4}>
+            <Grid item xs={12} sm={6} md={4}>
               <Chip
                 label="Twitter Card Meta Tags"
-                color={technical.social?.hasTwitterCard ? 'success' : 'default'}
-                variant={technical.social?.hasTwitterCard ? 'filled' : 'outlined'}
+                color={technical.social?.hasTwitterCard ? "success" : "default"}
+                variant={
+                  technical.social?.hasTwitterCard ? "filled" : "outlined"
+                }
                 size="small"
-                sx={{ width: '100%' }}
+                sx={{ width: "100%" }}
               />
             </Grid>
-            <Grid xs={12} sm={6} md={4}>
+            <Grid item xs={12} sm={6} md={4}>
               <Chip
                 label="Share Buttons"
-                color={technical.social?.hasShareButtons ? 'success' : 'default'}
-                variant={technical.social?.hasShareButtons ? 'filled' : 'outlined'}
+                color={
+                  technical.social?.hasShareButtons ? "success" : "default"
+                }
+                variant={
+                  technical.social?.hasShareButtons ? "filled" : "outlined"
+                }
                 size="small"
-                sx={{ width: '100%' }}
+                sx={{ width: "100%" }}
               />
             </Grid>
           </Grid>
@@ -229,14 +298,24 @@ const TechTab: React.FC<TechTabProps> = ({ data, loading, error }) => {
       {/* Cookie Banner & Consent Script Section */}
       <Card sx={{ borderRadius: 2, mb: 3 }}>
         <CardContent sx={{ p: 3 }}>
-          <Typography variant="h6" gutterBottom sx={{ fontWeight: 'bold', mb: 3 }}>
+          <Typography
+            variant="h6"
+            gutterBottom
+            sx={{ fontWeight: "bold", mb: 3 }}
+          >
             Detected Cookie Banner & Consent Script
           </Typography>
           <Grid container spacing={2}>
-            <Grid xs={12}>
+            <Grid item xs={12}>
               <Chip
-                label={technical.cookies?.hasCookieScript ? 'Cookie Consent Script Detected' : 'No Cookie Consent Script Found'}
-                color={technical.cookies?.hasCookieScript ? 'success' : 'warning'}
+                label={
+                  technical.cookies?.hasCookieScript
+                    ? "Cookie Consent Script Detected"
+                    : "No Cookie Consent Script Found"
+                }
+                color={
+                  technical.cookies?.hasCookieScript ? "success" : "warning"
+                }
                 variant="filled"
                 size="medium"
               />
@@ -248,26 +327,34 @@ const TechTab: React.FC<TechTabProps> = ({ data, loading, error }) => {
       {/* Minification Status Section */}
       <Card sx={{ borderRadius: 2, mb: 3 }}>
         <CardContent sx={{ p: 3 }}>
-          <Typography variant="h6" gutterBottom sx={{ fontWeight: 'bold', mb: 3 }}>
+          <Typography
+            variant="h6"
+            gutterBottom
+            sx={{ fontWeight: "bold", mb: 3 }}
+          >
             Minification Status
           </Typography>
           <Grid container spacing={2}>
-            <Grid xs={12} sm={6}>
+            <Grid item xs={12} sm={6}>
               <Chip
-                label={`CSS: ${technical.minification?.cssMinified ? 'Minified' : 'Not Minified'}`}
-                color={technical.minification?.cssMinified ? 'success' : 'warning'}
+                label={`CSS: ${technical.minification?.cssMinified ? "Minified" : "Not Minified"}`}
+                color={
+                  technical.minification?.cssMinified ? "success" : "warning"
+                }
                 variant="filled"
                 size="medium"
-                sx={{ width: '100%' }}
+                sx={{ width: "100%" }}
               />
             </Grid>
-            <Grid xs={12} sm={6}>
+            <Grid item xs={12} sm={6}>
               <Chip
-                label={`JavaScript: ${technical.minification?.jsMinified ? 'Minified' : 'Not Minified'}`}
-                color={technical.minification?.jsMinified ? 'success' : 'warning'}
+                label={`JavaScript: ${technical.minification?.jsMinified ? "Minified" : "Not Minified"}`}
+                color={
+                  technical.minification?.jsMinified ? "success" : "warning"
+                }
                 variant="filled"
                 size="medium"
-                sx={{ width: '100%' }}
+                sx={{ width: "100%" }}
               />
             </Grid>
           </Grid>
@@ -275,10 +362,10 @@ const TechTab: React.FC<TechTabProps> = ({ data, loading, error }) => {
       </Card>
 
       <Grid container spacing={3}>
-        <Grid xs={12} md={8}>
+        <Grid item xs={12} md={8}>
           <Card sx={{ borderRadius: 2 }}>
             <CardContent sx={{ p: 3 }}>
-              <Typography variant="h6" gutterBottom sx={{ fontWeight: 'bold' }}>
+              <Typography variant="h6" gutterBottom sx={{ fontWeight: "bold" }}>
                 Technical Issues
               </Typography>
               <Table>
@@ -302,7 +389,7 @@ const TechTab: React.FC<TechTabProps> = ({ data, loading, error }) => {
                           sx={{
                             backgroundColor: `${getSeverityColor(issue.severity)}20`,
                             color: getSeverityColor(issue.severity),
-                            fontWeight: 'medium'
+                            fontWeight: "medium",
                           }}
                         />
                       </TableCell>
@@ -315,45 +402,91 @@ const TechTab: React.FC<TechTabProps> = ({ data, loading, error }) => {
           </Card>
         </Grid>
 
-        <Grid xs={12} md={4}>
+        <Grid item xs={12} md={4}>
           <Card sx={{ borderRadius: 2 }}>
             <CardContent sx={{ p: 3 }}>
-              <Typography variant="h6" gutterBottom sx={{ fontWeight: 'bold' }}>
+              <Typography variant="h6" gutterBottom sx={{ fontWeight: "bold" }}>
                 Technical Health
               </Typography>
               <Box sx={{ mb: 3 }}>
-                <Typography variant="h3" sx={{
-                  fontWeight: 'bold',
-                  color: getHealthGradeColor(technical.healthGrade),
-                  textAlign: 'center'
-                }}>
+                <Typography
+                  variant="h3"
+                  sx={{
+                    fontWeight: "bold",
+                    color: getHealthGradeColor(technical.healthGrade),
+                    textAlign: "center",
+                  }}
+                >
                   {technical.healthGrade}
                 </Typography>
-                <Typography variant="body2" color="text.secondary" sx={{ textAlign: 'center' }}>
+                <Typography
+                  variant="body2"
+                  color="text.secondary"
+                  sx={{ textAlign: "center" }}
+                >
                   Technical Health Grade
                 </Typography>
               </Box>
-              
+
               <Box>
-                <Typography variant="subtitle2" sx={{ fontWeight: 'bold', mb: 2 }}>
+                <Typography
+                  variant="subtitle2"
+                  sx={{ fontWeight: "bold", mb: 2 }}
+                >
                   Issue Summary
                 </Typography>
-                <Box sx={{ display: 'flex', justifyContent: 'space-between', mb: 1 }}>
+                <Box
+                  sx={{
+                    display: "flex",
+                    justifyContent: "space-between",
+                    mb: 1,
+                  }}
+                >
                   <Typography variant="body2">High Severity</Typography>
-                  <Typography variant="body2" sx={{ fontWeight: 'bold', color: '#F44336' }}>
-                    {technical.issues.filter(i => i.severity === 'high').length}
+                  <Typography
+                    variant="body2"
+                    sx={{ fontWeight: "bold", color: "#F44336" }}
+                  >
+                    {
+                      technical.issues.filter((i) => i.severity === "high")
+                        .length
+                    }
                   </Typography>
                 </Box>
-                <Box sx={{ display: 'flex', justifyContent: 'space-between', mb: 1 }}>
+                <Box
+                  sx={{
+                    display: "flex",
+                    justifyContent: "space-between",
+                    mb: 1,
+                  }}
+                >
                   <Typography variant="body2">Medium Severity</Typography>
-                  <Typography variant="body2" sx={{ fontWeight: 'bold', color: '#FF9800' }}>
-                    {technical.issues.filter(i => i.severity === 'medium').length}
+                  <Typography
+                    variant="body2"
+                    sx={{ fontWeight: "bold", color: "#FF9800" }}
+                  >
+                    {
+                      technical.issues.filter((i) => i.severity === "medium")
+                        .length
+                    }
                   </Typography>
                 </Box>
-                <Box sx={{ display: 'flex', justifyContent: 'space-between', mb: 1 }}>
+                <Box
+                  sx={{
+                    display: "flex",
+                    justifyContent: "space-between",
+                    mb: 1,
+                  }}
+                >
                   <Typography variant="body2">Low Severity</Typography>
-                  <Typography variant="body2" sx={{ fontWeight: 'bold', color: '#4CAF50' }}>
-                    {technical.issues.filter(i => i.severity === 'low').length}
+                  <Typography
+                    variant="body2"
+                    sx={{ fontWeight: "bold", color: "#4CAF50" }}
+                  >
+                    {
+                      technical.issues.filter((i) => i.severity === "low")
+                        .length
+                    }
                   </Typography>
                 </Box>
               </Box>

--- a/src/components/dashboard/UIAnalysisTab.tsx
+++ b/src/components/dashboard/UIAnalysisTab.tsx
@@ -1,11 +1,10 @@
-
-import React from 'react';
-import { Box, Typography, Grid, CircularProgress, Alert } from '@mui/material';
-import type { AnalysisResponse } from '@/types/analysis';
-import ColorExtractionCard from './ui-analysis/ColorExtractionCard';
-import FontAnalysisCard from './ui-analysis/FontAnalysisCard';
-import ImageAnalysisCard from './ui-analysis/ImageAnalysisCard';
-import ContrastWarningsCard from './ui-analysis/ContrastWarningsCard';
+import React from "react";
+import { Box, Typography, Grid, CircularProgress, Alert } from "@mui/material";
+import type { AnalysisResponse } from "@/types/analysis";
+import ColorExtractionCard from "./ui-analysis/ColorExtractionCard";
+import FontAnalysisCard from "./ui-analysis/FontAnalysisCard";
+import ImageAnalysisCard from "./ui-analysis/ImageAnalysisCard";
+import ContrastWarningsCard from "./ui-analysis/ContrastWarningsCard";
 
 interface UIAnalysisTabProps {
   data: AnalysisResponse | null;
@@ -13,12 +12,25 @@ interface UIAnalysisTabProps {
   error: string | null;
 }
 
-const UIAnalysisTab: React.FC<UIAnalysisTabProps> = ({ data, loading, error }) => {
+const UIAnalysisTab: React.FC<UIAnalysisTabProps> = ({
+  data,
+  loading,
+  error,
+}) => {
   if (loading) {
     return (
-      <Box sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center', py: 8 }}>
+      <Box
+        sx={{
+          display: "flex",
+          justifyContent: "center",
+          alignItems: "center",
+          py: 8,
+        }}
+      >
         <CircularProgress size={60} />
-        <Typography variant="h6" sx={{ ml: 2 }}>Analyzing UI elements...</Typography>
+        <Typography variant="h6" sx={{ ml: 2 }}>
+          Analyzing UI elements...
+        </Typography>
       </Box>
     );
   }
@@ -40,37 +52,34 @@ const UIAnalysisTab: React.FC<UIAnalysisTabProps> = ({ data, loading, error }) =
   }
 
   const { colors, fonts, images, imageAnalysis } = data.data.ui;
-  
-  console.log('Image analysis data:', imageAnalysis);
-  
+
+  console.log("Image analysis data:", imageAnalysis);
+
   return (
     <Box>
-      <Typography variant="h5" gutterBottom sx={{ fontWeight: 'bold', mb: 3 }}>
+      <Typography variant="h5" gutterBottom sx={{ fontWeight: "bold", mb: 3 }}>
         User Interface Analysis
       </Typography>
 
-      <Grid container spacing={3}>
+      <Grid container spacing={3} alignItems="stretch">
         {/* Color Extraction */}
-        <Grid xs={12} md={6}>
+        <Grid item xs={12} sm={6} md={6} lg={6} xl={6} sx={{ display: "flex" }}>
           <ColorExtractionCard colors={colors} />
         </Grid>
 
         {/* Font Analysis */}
-        <Grid xs={12} md={6}>
+        <Grid item xs={12} sm={6} md={6} lg={6} xl={6} sx={{ display: "flex" }}>
           <FontAnalysisCard fonts={fonts} />
         </Grid>
 
         {/* Contrast Warnings */}
-        <Grid xs={12}>
+        <Grid item xs={12} sm={6} md={6} lg={6} xl={6} sx={{ display: "flex" }}>
           <ContrastWarningsCard issues={data.data.ui.contrastIssues} />
         </Grid>
 
         {/* Image Analysis */}
-        <Grid xs={12}>
-          <ImageAnalysisCard 
-            images={images} 
-            imageAnalysis={imageAnalysis} 
-          />
+        <Grid item xs={12} sx={{ display: "flex" }}>
+          <ImageAnalysisCard images={images} imageAnalysis={imageAnalysis} />
         </Grid>
       </Grid>
     </Box>

--- a/src/components/dashboard/ui-analysis/ImageAnalysisCard.tsx
+++ b/src/components/dashboard/ui-analysis/ImageAnalysisCard.tsx
@@ -1,12 +1,11 @@
-
-import React, { useState } from 'react';
-import { Box, Typography, Grid, Card, CardContent } from '@mui/material';
-import { Image } from 'lucide-react';
-import type { AnalysisResponse } from '@/types/analysis';
-import ExpandableImageBox from './ExpandableImageBox';
+import React, { useState } from "react";
+import { Box, Typography, Grid, Card, CardContent } from "@mui/material";
+import { Image } from "lucide-react";
+import type { AnalysisResponse } from "@/types/analysis";
+import ExpandableImageBox from "./ExpandableImageBox";
 
 interface ImageAnalysisCardProps {
-  images: AnalysisResponse['data']['ui']['images'];
+  images: AnalysisResponse["data"]["ui"]["images"];
   imageAnalysis?: {
     totalImages: number;
     estimatedPhotos: number;
@@ -17,33 +16,55 @@ interface ImageAnalysisCardProps {
   };
 }
 
-const ImageAnalysisCard: React.FC<ImageAnalysisCardProps> = ({ images, imageAnalysis }) => {
+const ImageAnalysisCard: React.FC<ImageAnalysisCardProps> = ({
+  images,
+  imageAnalysis,
+}) => {
   const [expandedTotal, setExpandedTotal] = useState(false);
   const [expandedPhotos, setExpandedPhotos] = useState(false);
   const [expandedIcons, setExpandedIcons] = useState(false);
 
   // Debug logging
-  console.log('ImageAnalysisCard received imageAnalysis:', imageAnalysis);
-  console.log('ImageAnalysisCard received images:', images);
+  console.log("ImageAnalysisCard received imageAnalysis:", imageAnalysis);
+  console.log("ImageAnalysisCard received images:", images);
 
   // Use real scraped URLs, make sure they're arrays even if undefined
   const imageUrls = imageAnalysis?.imageUrls || [];
   const photoUrls = imageAnalysis?.photoUrls || [];
   const iconUrls = imageAnalysis?.iconUrls || [];
 
-  console.log('Processed URLs:', { imageUrls: imageUrls.length, photoUrls: photoUrls.length, iconUrls: iconUrls.length });
+  console.log("Processed URLs:", {
+    imageUrls: imageUrls.length,
+    photoUrls: photoUrls.length,
+    iconUrls: iconUrls.length,
+  });
 
-  const totalImagesCount = imageAnalysis?.totalImages || images.reduce((acc, img) => acc + img.count, 0);
-  const photosCount = imageAnalysis?.estimatedPhotos || images.find(img => img.type === 'Estimated Photos')?.count || 0;
-  const iconsCount = imageAnalysis?.estimatedIcons || images.find(img => img.type === 'Estimated Icons')?.count || 0;
+  const totalImagesCount =
+    imageAnalysis?.totalImages ||
+    images.reduce((acc, img) => acc + img.count, 0);
+  const photosCount =
+    imageAnalysis?.estimatedPhotos ||
+    images.find((img) => img.type === "Estimated Photos")?.count ||
+    0;
+  const iconsCount =
+    imageAnalysis?.estimatedIcons ||
+    images.find((img) => img.type === "Estimated Icons")?.count ||
+    0;
 
   return (
     <Card sx={{ borderRadius: 2 }}>
       <CardContent sx={{ p: 3 }}>
-        <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', mb: 3 }}>
-          <Box sx={{ display: 'flex', alignItems: 'center' }}>
+        <Box
+          sx={{
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "space-between",
+            mb: 3,
+          }}
+        >
+          <Box sx={{ display: "flex", alignItems: "center" }}>
             <Image size={24} color="#FF6B35" style={{ marginRight: 8 }} />
-            <Typography variant="h6" sx={{ fontWeight: 'bold' }}>
+            <Typography variant="h6" sx={{ fontWeight: "bold" }}>
               Image Analysis
             </Typography>
           </Box>
@@ -51,15 +72,18 @@ const ImageAnalysisCard: React.FC<ImageAnalysisCardProps> = ({ images, imageAnal
             Total: {totalImagesCount} assets
           </Typography>
         </Box>
-        
+
         <Grid container spacing={2}>
           {/* Total Images Box */}
-          <Grid xs={12} sm={6} md={4}>
+          <Grid item xs={12} sm={6} md={4}>
             <ExpandableImageBox
               title="Total Images"
               count={totalImagesCount}
               format="Mixed"
-              totalSize={images.find(img => img.type === 'Total Images')?.totalSize || '0KB'}
+              totalSize={
+                images.find((img) => img.type === "Total Images")?.totalSize ||
+                "0KB"
+              }
               isExpanded={expandedTotal}
               onToggle={() => setExpandedTotal(!expandedTotal)}
               urls={imageUrls}
@@ -68,12 +92,18 @@ const ImageAnalysisCard: React.FC<ImageAnalysisCardProps> = ({ images, imageAnal
           </Grid>
 
           {/* Estimated Photos Box */}
-          <Grid xs={12} sm={6} md={4}>
+          <Grid item xs={12} sm={6} md={4}>
             <ExpandableImageBox
               title="Estimated Photos"
               count={photosCount}
-              format={images.find(img => img.type === 'Estimated Photos')?.format || 'JPG/PNG'}
-              totalSize={images.find(img => img.type === 'Estimated Photos')?.totalSize || '0KB'}
+              format={
+                images.find((img) => img.type === "Estimated Photos")?.format ||
+                "JPG/PNG"
+              }
+              totalSize={
+                images.find((img) => img.type === "Estimated Photos")
+                  ?.totalSize || "0KB"
+              }
               isExpanded={expandedPhotos}
               onToggle={() => setExpandedPhotos(!expandedPhotos)}
               urls={photoUrls}
@@ -82,12 +112,18 @@ const ImageAnalysisCard: React.FC<ImageAnalysisCardProps> = ({ images, imageAnal
           </Grid>
 
           {/* Estimated Icons Box */}
-          <Grid xs={12} sm={6} md={4}>
+          <Grid item xs={12} sm={6} md={4}>
             <ExpandableImageBox
               title="Estimated Icons"
               count={iconsCount}
-              format={images.find(img => img.type === 'Estimated Icons')?.format || 'SVG/PNG'}
-              totalSize={images.find(img => img.type === 'Estimated Icons')?.totalSize || '0KB'}
+              format={
+                images.find((img) => img.type === "Estimated Icons")?.format ||
+                "SVG/PNG"
+              }
+              totalSize={
+                images.find((img) => img.type === "Estimated Icons")
+                  ?.totalSize || "0KB"
+              }
               isExpanded={expandedIcons}
               onToggle={() => setExpandedIcons(!expandedIcons)}
               urls={iconUrls}


### PR DESCRIPTION
## Summary
- keep overview metric cards stretched for consistent size
- standardize widths across UI analysis cards
- render overview metrics as two columns
- add missing `item` prop across dashboard grids for uniform card widths

## Testing
- `npm run test`
- `npx tsc -p tsconfig.json --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_684528290728832bbc3f3dec5092ecf8