### PR TITLE
Update UI grid to MUI v2 API

### DIFF
--- a/src/components/dashboard/UIAnalysisTab.tsx
+++ b/src/components/dashboard/UIAnalysisTab.tsx
@@ -52,27 +52,27 @@ const UIAnalysisTab: React.FC<UIAnalysisTabProps> = ({ data, loading, error }) =
       <Grid container spacing={3} alignItems="stretch" columns={{ xs: 12, md: 12 }}>
         {/* Color Extraction */}
 
-        <Grid item xs={12} md={6} lg={6} sx={{ display: 'flex', width: '100%' }}>
+        <Grid xs={12} md={6} lg={6} sx={{ display: 'flex', width: '100%' }}>
 
           <ColorExtractionCard colors={colors} />
         </Grid>
 
         {/* Font Analysis */}
 
-        <Grid item xs={12} md={6} lg={6} sx={{ display: 'flex', width: '100%' }}>
+        <Grid xs={12} md={6} lg={6} sx={{ display: 'flex', width: '100%' }}>
 
           <FontAnalysisCard fonts={fonts} />
         </Grid>
 
         {/* Contrast Warnings */}
 
-        <Grid item xs={12} md={6} lg={6} sx={{ display: 'flex', width: '100%' }}>
+        <Grid xs={12} md={6} lg={6} sx={{ display: 'flex', width: '100%' }}>
 
           <ContrastWarningsCard issues={data.data.ui.contrastIssues} />
         </Grid>
 
         {/* Image Analysis */}
-        <Grid item xs={12} sx={{ display: 'flex', width: '100%' }}>
+        <Grid xs={12} sx={{ display: 'flex', width: '100%' }}>
 
           <ImageAnalysisCard
             images={images}


### PR DESCRIPTION
## Summary
- remove deprecated `item` prop from `UIAnalysisTab` grid layout

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6845ab7492a4832bb3cd82286a93e44f