### PR TITLE
Fix grid layout widths

### DIFF
--- a/src/components/dashboard/OverviewTab.tsx
+++ b/src/components/dashboard/OverviewTab.tsx
@@ -80,7 +80,7 @@ const OverviewTab: React.FC<OverviewTabProps> = ({ data, loading, error }) => {
             <Grid
               item xs={6} sm={6} md={6} lg={6}
               key={index}
-              sx={{ display: 'flex', width: '100%' }}
+              sx={{ display: 'flex' }}
             >
               <Card sx={{ height: '100%', borderRadius: 2, flexGrow: 1 }}>
 

--- a/src/components/dashboard/UIAnalysisTab.tsx
+++ b/src/components/dashboard/UIAnalysisTab.tsx
@@ -52,27 +52,27 @@ const UIAnalysisTab: React.FC<UIAnalysisTabProps> = ({ data, loading, error }) =
       <Grid container spacing={3} alignItems="stretch" columns={{ xs: 12, md: 12 }}>
         {/* Color Extraction */}
 
-        <Grid xs={12} md={6} lg={6} sx={{ display: 'flex', width: '100%' }}>
+        <Grid xs={12} md={6} lg={6} sx={{ display: 'flex' }}>
 
           <ColorExtractionCard colors={colors} />
         </Grid>
 
         {/* Font Analysis */}
 
-        <Grid xs={12} md={6} lg={6} sx={{ display: 'flex', width: '100%' }}>
+        <Grid xs={12} md={6} lg={6} sx={{ display: 'flex' }}>
 
           <FontAnalysisCard fonts={fonts} />
         </Grid>
 
         {/* Contrast Warnings */}
 
-        <Grid xs={12} md={6} lg={6} sx={{ display: 'flex', width: '100%' }}>
+        <Grid xs={12} md={6} lg={6} sx={{ display: 'flex' }}>
 
           <ContrastWarningsCard issues={data.data.ui.contrastIssues} />
         </Grid>
 
         {/* Image Analysis */}
-        <Grid xs={12} sx={{ display: 'flex', width: '100%' }}>
+        <Grid xs={12} sx={{ display: 'flex' }}>
 
           <ImageAnalysisCard
             images={images}


### PR DESCRIPTION
## Summary
- adjust dashboard grid items to stop forcing full-width

## Testing
- `npm run test`
- `npx tsc -p tsconfig.json --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_68463fb76d48832ba3a24e2171c6d028