### PR TITLE
Refactor UIAnalysis layout

### DIFF
--- a/src/components/dashboard/UIAnalysisTab.tsx
+++ b/src/components/dashboard/UIAnalysisTab.tsx
@@ -1,6 +1,6 @@
 
 import React from 'react';
-import { Box, Typography, Grid, CircularProgress, Alert } from '@mui/material';
+import { Box, Typography, Grid, Card, CardContent, CircularProgress, Alert } from '@mui/material';
 import type { AnalysisResponse } from '@/types/analysis';
 import ColorExtractionCard from './ui-analysis/ColorExtractionCard';
 import FontAnalysisCard from './ui-analysis/FontAnalysisCard';
@@ -41,8 +41,6 @@ const UIAnalysisTab: React.FC<UIAnalysisTabProps> = ({ data, loading, error }) =
 
   const { colors, fonts, images, imageAnalysis } = data.data.ui;
   
-  console.log('Image analysis data:', imageAnalysis);
-  
   return (
     <Box>
       <Typography variant="h5" gutterBottom sx={{ fontWeight: 'bold', mb: 3 }}>
@@ -51,40 +49,42 @@ const UIAnalysisTab: React.FC<UIAnalysisTabProps> = ({ data, loading, error }) =
 
       <Grid container spacing={2} alignItems="stretch">
         {/* Color Extraction */}
-
         <Grid xs={12} md={6} sx={{ display: 'flex' }}>
-
-
-          <ColorExtractionCard colors={colors} />
+          <Card sx={{ borderRadius: 2, flexGrow: 1 }}>
+            <CardContent sx={{ p: 3 }}>
+              <ColorExtractionCard colors={colors} />
+            </CardContent>
+          </Card>
         </Grid>
 
         {/* Font Analysis */}
-
         <Grid xs={12} md={6} sx={{ display: 'flex' }}>
-
-
-
-          <FontAnalysisCard fonts={fonts} />
+          <Card sx={{ borderRadius: 2, flexGrow: 1 }}>
+            <CardContent sx={{ p: 3 }}>
+              <FontAnalysisCard fonts={fonts} />
+            </CardContent>
+          </Card>
         </Grid>
 
         {/* Contrast Warnings */}
-
         <Grid xs={12} md={6} sx={{ display: 'flex' }}>
-
-
-
-          <ContrastWarningsCard issues={data.data.ui.contrastIssues} />
+          <Card sx={{ borderRadius: 2, flexGrow: 1 }}>
+            <CardContent sx={{ p: 3 }}>
+              <ContrastWarningsCard issues={data.data.ui.contrastIssues} />
+            </CardContent>
+          </Card>
         </Grid>
 
         {/* Image Analysis */}
-
         <Grid xs={12} md={6} sx={{ display: 'flex' }}>
-
-
-          <ImageAnalysisCard
-            images={images}
-            imageAnalysis={imageAnalysis}
-          />
+          <Card sx={{ borderRadius: 2, flexGrow: 1 }}>
+            <CardContent sx={{ p: 3 }}>
+              <ImageAnalysisCard
+                images={images}
+                imageAnalysis={imageAnalysis}
+              />
+            </CardContent>
+          </Card>
         </Grid>
       </Grid>
     </Box>

--- a/src/components/dashboard/ui-analysis/ColorExtractionCard.tsx
+++ b/src/components/dashboard/ui-analysis/ColorExtractionCard.tsx
@@ -1,6 +1,6 @@
 
 import React, { useState } from 'react';
-import { Box, Typography, Card, CardContent, Collapse, IconButton, Grid } from '@mui/material';
+import { Box, Typography, Collapse, IconButton, Grid } from '@mui/material';
 import { Palette, ChevronDown, ChevronUp } from 'lucide-react';
 import type { AnalysisResponse } from '@/types/analysis';
 import { groupByFrequency } from '@/lib/ui';
@@ -153,8 +153,7 @@ const ColorExtractionCard: React.FC<ColorExtractionCardProps> = ({ colors }) => 
   }, [colors]);
 
   return (
-    <Card sx={{ borderRadius: 2, height: '100%' }}>
-      <CardContent sx={{ p: 3 }}>
+    <Box>
         <Box sx={{ display: 'flex', alignItems: 'center', mb: 3 }}>
           <Palette size={24} color="#FF6B35" style={{ marginRight: 8 }} />
           <Typography variant="h6" sx={{ fontWeight: 'bold' }}>
@@ -277,8 +276,7 @@ const ColorExtractionCard: React.FC<ColorExtractionCardProps> = ({ colors }) => 
             </Box>
           ))}
         </Box>
-      </CardContent>
-    </Card>
+    </Box>
   );
 };
 

--- a/src/components/dashboard/ui-analysis/ContrastWarningsCard.tsx
+++ b/src/components/dashboard/ui-analysis/ContrastWarningsCard.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Box, Typography, Card, CardContent } from '@mui/material';
+import { Box, Typography } from '@mui/material';
 import { AlertTriangle } from 'lucide-react';
 import type { AnalysisResponse } from '@/types/analysis';
 
@@ -10,8 +10,7 @@ interface ContrastWarningsCardProps {
 const ContrastWarningsCard: React.FC<ContrastWarningsCardProps> = ({ issues }) => {
   if (!issues.length) {
     return (
-      <Card sx={{ borderRadius: 2 }}>
-        <CardContent sx={{ p: 3 }}>
+      <Box>
           <Box sx={{ display: 'flex', alignItems: 'center', mb: 2 }}>
             <AlertTriangle size={24} color="#FF6B35" style={{ marginRight: 8 }} />
             <Typography variant="h6" sx={{ fontWeight: 'bold' }}>
@@ -19,13 +18,11 @@ const ContrastWarningsCard: React.FC<ContrastWarningsCardProps> = ({ issues }) =
             </Typography>
           </Box>
           <Typography variant="body2">No contrast issues detected.</Typography>
-        </CardContent>
-      </Card>
+      </Box>
     );
   }
   return (
-    <Card sx={{ borderRadius: 2 }}>
-      <CardContent sx={{ p: 3 }}>
+    <Box>
         <Box sx={{ display: 'flex', alignItems: 'center', mb: 2 }}>
           <AlertTriangle size={24} color="#FF6B35" style={{ marginRight: 8 }} />
           <Typography variant="h6" sx={{ fontWeight: 'bold' }}>
@@ -39,8 +36,7 @@ const ContrastWarningsCard: React.FC<ContrastWarningsCardProps> = ({ issues }) =
             </Typography>
           </Box>
         ))}
-      </CardContent>
-    </Card>
+    </Box>
   );
 };
 

--- a/src/components/dashboard/ui-analysis/ExpandableImageBox.tsx
+++ b/src/components/dashboard/ui-analysis/ExpandableImageBox.tsx
@@ -24,8 +24,6 @@ const ExpandableImageBox: React.FC<ExpandableImageBoxProps> = ({
   urls,
   emptyMessage,
 }) => {
-  // Debug logging
-  console.log(`ExpandableImageBox ${title}:`, { count, urlsLength: urls?.length, urls: urls?.slice(0, 3) });
 
   return (
     <Box

--- a/src/components/dashboard/ui-analysis/FontAnalysisCard.tsx
+++ b/src/components/dashboard/ui-analysis/FontAnalysisCard.tsx
@@ -1,6 +1,6 @@
 
 import React from 'react';
-import { Box, Typography, Card, CardContent, Chip } from '@mui/material';
+import { Box, Typography, Chip } from '@mui/material';
 import { Type } from 'lucide-react';
 import type { AnalysisResponse } from '@/types/analysis';
 
@@ -10,8 +10,7 @@ interface FontAnalysisCardProps {
 
 const FontAnalysisCard: React.FC<FontAnalysisCardProps> = ({ fonts }) => {
   return (
-    <Card sx={{ borderRadius: 2, height: '100%' }}>
-      <CardContent sx={{ p: 3 }}>
+    <Box>
         <Box sx={{ display: 'flex', alignItems: 'center', mb: 3 }}>
           <Type size={24} color="#FF6B35" style={{ marginRight: 8 }} />
           <Typography variant="h6" sx={{ fontWeight: 'bold' }}>
@@ -35,8 +34,7 @@ const FontAnalysisCard: React.FC<FontAnalysisCardProps> = ({ fonts }) => {
             </Box>
           ))}
         </Box>
-      </CardContent>
-    </Card>
+    </Box>
   );
 };
 

--- a/src/components/dashboard/ui-analysis/ImageAnalysisCard.tsx
+++ b/src/components/dashboard/ui-analysis/ImageAnalysisCard.tsx
@@ -1,6 +1,6 @@
 
 import React, { useState } from 'react';
-import { Box, Typography, Grid, Card, CardContent } from '@mui/material';
+import { Box, Typography, Grid } from '@mui/material';
 import { Image } from 'lucide-react';
 import type { AnalysisResponse } from '@/types/analysis';
 import ExpandableImageBox from './ExpandableImageBox';
@@ -22,24 +22,19 @@ const ImageAnalysisCard: React.FC<ImageAnalysisCardProps> = ({ images, imageAnal
   const [expandedPhotos, setExpandedPhotos] = useState(false);
   const [expandedIcons, setExpandedIcons] = useState(false);
 
-  // Debug logging
-  console.log('ImageAnalysisCard received imageAnalysis:', imageAnalysis);
-  console.log('ImageAnalysisCard received images:', images);
 
   // Use real scraped URLs, make sure they're arrays even if undefined
   const imageUrls = imageAnalysis?.imageUrls || [];
   const photoUrls = imageAnalysis?.photoUrls || [];
   const iconUrls = imageAnalysis?.iconUrls || [];
 
-  console.log('Processed URLs:', { imageUrls: imageUrls.length, photoUrls: photoUrls.length, iconUrls: iconUrls.length });
 
   const totalImagesCount = imageAnalysis?.totalImages || images.reduce((acc, img) => acc + img.count, 0);
   const photosCount = imageAnalysis?.estimatedPhotos || images.find(img => img.type === 'Estimated Photos')?.count || 0;
   const iconsCount = imageAnalysis?.estimatedIcons || images.find(img => img.type === 'Estimated Icons')?.count || 0;
 
   return (
-    <Card sx={{ borderRadius: 2 }}>
-      <CardContent sx={{ p: 3 }}>
+    <Box>
         <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', mb: 3 }}>
           <Box sx={{ display: 'flex', alignItems: 'center' }}>
             <Image size={24} color="#FF6B35" style={{ marginRight: 8 }} />
@@ -95,8 +90,7 @@ const ImageAnalysisCard: React.FC<ImageAnalysisCardProps> = ({ images, imageAnal
             />
           </Grid>
         </Grid>
-      </CardContent>
-    </Card>
+    </Box>
   );
 };
 


### PR DESCRIPTION
## Summary
- update UI analysis card components to render without their own Card wrapper
- clean up ExpandableImageBox logging

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684700e2b228832b85619accb51c3af8