### PR TITLE
Fix full-width color extraction card

### DIFF
--- a/src/components/dashboard/UIAnalysisTab.tsx
+++ b/src/components/dashboard/UIAnalysisTab.tsx
@@ -49,8 +49,8 @@ const UIAnalysisTab: React.FC<UIAnalysisTabProps> = ({ data, loading, error }) =
 
       <Grid container spacing={2} alignItems="stretch">
         {/* Color Extraction */}
-        <Grid xs={12} md={12} sx={{ display: 'flex' }} >
-          <Card sx={{ borderRadius: 2, flexGrow: 1 }}>
+        <Grid xs={12} sx={{ display: 'flex', width: '100%' }}>
+          <Card sx={{ borderRadius: 2, flexGrow: 1, width: '100%' }}>
             <CardContent sx={{ p: 3 }}>
               <ColorExtractionCard colors={colors} />
             </CardContent>


### PR DESCRIPTION
## Summary
- make Color Extraction card span full width of the grid

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6848132522d8832b9c6d20e02f7acd46