### PR TITLE
Fix performance tab grid layout

### DIFF
--- a/src/components/dashboard/PerformanceTab.tsx
+++ b/src/components/dashboard/PerformanceTab.tsx
@@ -68,7 +68,7 @@ const PerformanceTab: React.FC<PerformanceTabProps> = ({ data, loading, error })
 
       {/* Performance Score Section */}
       <Grid container spacing={2} alignItems="stretch" sx={{ mb: 4 }}>
-        <Grid xs={12} md={4} sx={{ display: 'flex' }}>
+        <Grid item xs={12} md={4} sx={{ display: 'flex' }}>
           <Card sx={{ borderRadius: 2, flexGrow: 1 }}>
             <CardContent sx={{ p: 3, textAlign: 'center' }}>
               <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'center', mb: 2 }}>
@@ -87,7 +87,7 @@ const PerformanceTab: React.FC<PerformanceTabProps> = ({ data, loading, error })
           </Card>
         </Grid>
 
-        <Grid xs={12} md={4} sx={{ display: 'flex' }}>
+        <Grid item xs={12} md={4} sx={{ display: 'flex' }}>
           <Card sx={{ borderRadius: 2, flexGrow: 1 }}>
             <CardContent sx={{ p: 3, textAlign: 'center' }}>
               <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'center', mb: 2 }}>
@@ -106,7 +106,7 @@ const PerformanceTab: React.FC<PerformanceTabProps> = ({ data, loading, error })
           </Card>
         </Grid>
 
-        <Grid xs={12} md={4} sx={{ display: 'flex' }}>
+        <Grid item xs={12} md={4} sx={{ display: 'flex' }}>
           <Card sx={{ borderRadius: 2, flexGrow: 1 }}>
             <CardContent sx={{ p: 3, textAlign: 'center' }}>
               <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'center', mb: 2 }}>
@@ -128,7 +128,7 @@ const PerformanceTab: React.FC<PerformanceTabProps> = ({ data, loading, error })
 
       {/* Core Web Vitals Section */}
       <Grid container spacing={2} alignItems="stretch" sx={{ mb: 4 }}>
-        <Grid xs={12} md={8} sx={{ display: 'flex' }}>
+        <Grid item xs={12} md={8} sx={{ display: 'flex' }}>
           <Card sx={{ borderRadius: 2, height: '400px', flexGrow: 1 }}>
             <CardContent sx={{ p: 3, height: '100%' }}>
               <Typography variant="h6" gutterBottom sx={{ fontWeight: 'bold' }}>
@@ -147,7 +147,7 @@ const PerformanceTab: React.FC<PerformanceTabProps> = ({ data, loading, error })
           </Card>
         </Grid>
 
-        <Grid xs={12} md={4} sx={{ display: 'flex' }}>
+        <Grid item xs={12} md={4} sx={{ display: 'flex' }}>
           <Card sx={{ borderRadius: 2, flexGrow: 1 }}>
             <CardContent sx={{ p: 3 }}>
               <Typography variant="h6" gutterBottom sx={{ fontWeight: 'bold' }}>
@@ -177,9 +177,9 @@ const PerformanceTab: React.FC<PerformanceTabProps> = ({ data, loading, error })
             </Typography>
             <Grid container spacing={2}>
               {Object.entries(data.securityHeaders).map(([key, value]) => (
-                <Grid xs={12} sm={6} md={4} key={key}>
-                  <Box sx={{ 
-                    p: 2, 
+                <Grid item xs={12} sm={6} md={4} key={key}>
+                  <Box sx={{
+                    p: 2,
                     border: '1px solid #E0E0E0',
                     borderRadius: 1,
                     display: 'flex',
@@ -212,10 +212,10 @@ const PerformanceTab: React.FC<PerformanceTabProps> = ({ data, loading, error })
             </Typography>
             <Grid container spacing={2}>
               {performance.recommendations.map((rec, index) => (
-                <Grid xs={12} md={6} key={index}>
-                  <Box sx={{ 
-                    p: 2, 
-                    backgroundColor: rec.type === 'warning' ? '#FFF3E0' : rec.type === 'error' ? '#FFEBEE' : '#E8F5E8', 
+                <Grid item xs={12} md={6} key={index}>
+                  <Box sx={{
+                    p: 2,
+                    backgroundColor: rec.type === 'warning' ? '#FFF3E0' : rec.type === 'error' ? '#FFEBEE' : '#E8F5E8',
                     borderRadius: 1, 
                     mb: 2 
                   }}>


### PR DESCRIPTION
## Summary
- fix Grid layout for equal spacing across the performance cards

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run test`

------
https://chatgpt.com/codex/tasks/task_e_68481639debc832bb6f81438b90a0057