### PR TITLE
Use MUI Grid auto layout for image analysis boxes

### DIFF
--- a/src/components/dashboard/ui-analysis/ImageAnalysisCard.tsx
+++ b/src/components/dashboard/ui-analysis/ImageAnalysisCard.tsx
@@ -49,7 +49,7 @@ const ImageAnalysisCard: React.FC<ImageAnalysisCardProps> = ({ images, imageAnal
         
         <Grid container spacing={2}>
           {/* Total Images Box */}
-          <Grid xs={12} sm={6} md={4}>
+          <Grid xs>
             <ExpandableImageBox
               title="Total Images"
               count={totalImagesCount}
@@ -63,7 +63,7 @@ const ImageAnalysisCard: React.FC<ImageAnalysisCardProps> = ({ images, imageAnal
           </Grid>
 
           {/* Estimated Photos Box */}
-          <Grid xs={12} sm={6} md={4}>
+          <Grid xs>
             <ExpandableImageBox
               title="Estimated Photos"
               count={photosCount}
@@ -77,7 +77,7 @@ const ImageAnalysisCard: React.FC<ImageAnalysisCardProps> = ({ images, imageAnal
           </Grid>
 
           {/* Estimated Icons Box */}
-          <Grid xs={12} sm={6} md={4}>
+          <Grid xs>
             <ExpandableImageBox
               title="Estimated Icons"
               count={iconsCount}


### PR DESCRIPTION
## Summary
- ensure ImageAnalysisCard uses MUI auto-layout so the three image sections share space equally

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68484008ba40832ba606ac4f621770db