### PR TITLE
Fix Image Analysis box spacing

### DIFF
--- a/src/components/dashboard/ui-analysis/ImageAnalysisCard.tsx
+++ b/src/components/dashboard/ui-analysis/ImageAnalysisCard.tsx
@@ -49,7 +49,7 @@ const ImageAnalysisCard: React.FC<ImageAnalysisCardProps> = ({ images, imageAnal
         
         <Grid container spacing={2}>
           {/* Total Images Box */}
-          <Grid xs>
+          <Grid item xs={12} sm={4}>
             <ExpandableImageBox
               title="Total Images"
               count={totalImagesCount}
@@ -63,7 +63,7 @@ const ImageAnalysisCard: React.FC<ImageAnalysisCardProps> = ({ images, imageAnal
           </Grid>
 
           {/* Estimated Photos Box */}
-          <Grid xs>
+          <Grid item xs={12} sm={4}>
             <ExpandableImageBox
               title="Estimated Photos"
               count={photosCount}
@@ -77,7 +77,7 @@ const ImageAnalysisCard: React.FC<ImageAnalysisCardProps> = ({ images, imageAnal
           </Grid>
 
           {/* Estimated Icons Box */}
-          <Grid xs>
+          <Grid item xs={12} sm={4}>
             <ExpandableImageBox
               title="Estimated Icons"
               count={iconsCount}


### PR DESCRIPTION
## Summary
- fix grid item props to distribute ImageAnalysis boxes evenly

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684844612d64832b93fe4f7c6089ed59