### PR TITLE
Allow URL input validation to accept uppercase letters

### DIFF
--- a/src/components/URLInputForm.tsx
+++ b/src/components/URLInputForm.tsx
@@ -27,7 +27,7 @@ const URLInputForm = () => {
   ];
 
   const validateUrl = (value: string) => {
-    const urlPattern = /^(https?:\/\/)?([\da-z\.-]+)\.([a-z\.]{2,6})([\/\w \.-]*)*\/?$/;
+    const urlPattern = /^(https?:\/\/)?([\da-z\.-]+)\.([a-z\.]{2,6})([\/\w \.-]*)*\/?$/i;
     return urlPattern.test(value) || value === '';
   };
 


### PR DESCRIPTION
## Summary
- update URL validation regex in `URLInputForm` to be case-insensitive so capital letters are accepted

## Testing
- `npm run test`
- `npx tsc -p tsconfig.json --noEmit`

------
https://chatgpt.com/codex/tasks/task_e_6849997e0554832bb1fcc958d6db9547