### PR TITLE
Center UI analysis columns

### DIFF
--- a/src/components/dashboard/UIAnalysisTab.tsx
+++ b/src/components/dashboard/UIAnalysisTab.tsx
@@ -57,22 +57,23 @@ const UIAnalysisTab: React.FC<UIAnalysisTabProps> = ({ data, loading, error }) =
           </Card>
         </Grid>
 
-        {/* Font Analysis */}
-        <Grid item xs={12} md={6} sx={{ display: 'flex' }}>
-          <Card sx={{ borderRadius: 2, flexGrow: 1 }}>
-            <CardContent sx={{ p: 3 }}>
-              <FontAnalysisCard fonts={fonts} />
-            </CardContent>
-          </Card>
-        </Grid>
+        {/* Font Analysis & Contrast Warnings */}
+        <Grid container item xs={12} spacing={2} justifyContent="center">
+          <Grid item xs={12} md={6} sx={{ display: 'flex' }}>
+            <Card sx={{ borderRadius: 2, flexGrow: 1, width: '100%' }}>
+              <CardContent sx={{ p: 3 }}>
+                <FontAnalysisCard fonts={fonts} />
+              </CardContent>
+            </Card>
+          </Grid>
 
-        {/* Contrast Warnings */}
-        <Grid item xs={12} md={6} sx={{ display: 'flex' }}>
-          <Card sx={{ borderRadius: 2, flexGrow: 1 }}>
-            <CardContent sx={{ p: 3 }}>
-              <ContrastWarningsCard issues={data.data.ui.contrastIssues} />
-            </CardContent>
-          </Card>
+          <Grid item xs={12} md={6} sx={{ display: 'flex' }}>
+            <Card sx={{ borderRadius: 2, flexGrow: 1, width: '100%' }}>
+              <CardContent sx={{ p: 3 }}>
+                <ContrastWarningsCard issues={data.data.ui.contrastIssues} />
+              </CardContent>
+            </Card>
+          </Grid>
         </Grid>
 
         {/* Image Analysis */}


### PR DESCRIPTION
## Summary
- tweak UI Analysis grid so Font Analysis and Contrast Warnings are centered columns

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6849a2f1a3e4832ba1c5e6b0583e8594