### PR TITLE
Implement auto-layout for performance metrics

### DIFF
--- a/src/components/dashboard/PerformanceTab.tsx
+++ b/src/components/dashboard/PerformanceTab.tsx
@@ -2,7 +2,7 @@
 import React from 'react';
 import { Box, Typography, Grid, Card, CardContent, LinearProgress, CircularProgress, Alert, Chip } from '@mui/material';
 import { ChartContainer, ChartTooltip, ChartTooltipContent } from '../ui/chart';
-import { BarChart, Bar, XAxis, YAxis, ResponsiveContainer } from 'recharts';
+import { BarChart, Bar, XAxis, YAxis } from 'recharts';
 import { Shield, Smartphone, Zap } from 'lucide-react';
 import type { AnalysisResponse } from '@/types/analysis';
 
@@ -50,6 +50,35 @@ const PerformanceTab: React.FC<PerformanceTabProps> = ({ data, loading, error })
     return '#F44336';
   };
 
+  const metrics = [
+    {
+      title: 'Performance Score',
+      value: performance.performanceScore.toString(),
+      icon: Zap,
+      color: getScoreColor(performance.performanceScore),
+      description:
+        performance.performanceScore >= 90
+          ? 'Excellent Performance'
+          : performance.performanceScore >= 70
+            ? 'Good Performance'
+            : 'Needs Improvement'
+    },
+    {
+      title: 'Mobile Responsiveness',
+      value: '—',
+      icon: Smartphone,
+      color: '#4CAF50',
+      description: 'Not yet implemented'
+    },
+    {
+      title: 'Security Score',
+      value: '—',
+      icon: Shield,
+      color: '#4CAF50',
+      description: 'Based on security headers'
+    }
+  ];
+
   return (
     <Box>
       <Typography variant="h5" gutterBottom sx={{ fontWeight: 'bold', mb: 3 }}>
@@ -58,62 +87,32 @@ const PerformanceTab: React.FC<PerformanceTabProps> = ({ data, loading, error })
 
       {/* Performance Score Section */}
       <Grid container spacing={3} sx={{ mb: 4 }}>
-        <Grid item xs={12} md={4}>
-          <Card sx={{ borderRadius: 2 }}>
-            <CardContent sx={{ p: 3, textAlign: 'center' }}>
-              <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'center', mb: 2 }}>
-                <Zap size={24} color="#FF6B35" style={{ marginRight: 8 }} />
-                <Typography variant="h6" sx={{ fontWeight: 'bold' }}>
-                  Performance Score
-                </Typography>
-              </Box>
-              <Typography variant="h2" sx={{ fontWeight: 'bold', color: getScoreColor(performance.performanceScore) }}>
-                {performance.performanceScore}
-              </Typography>
-              <Typography variant="body2" color="text.primary">
-                {performance.performanceScore >= 90 ? 'Excellent' : performance.performanceScore >= 70 ? 'Good' : 'Needs Improvement'} Performance
-              </Typography>
-            </CardContent>
-          </Card>
-        </Grid>
-
-        <Grid item xs={12} md={4}>
-          <Card sx={{ borderRadius: 2 }}>
-            <CardContent sx={{ p: 3, textAlign: 'center' }}>
-              <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'center', mb: 2 }}>
-                <Smartphone size={24} color="#FF6B35" style={{ marginRight: 8 }} />
-                <Typography variant="h6" sx={{ fontWeight: 'bold' }}>
-                  Mobile Responsiveness
-                </Typography>
-              </Box>
-              <Typography variant="h3" sx={{ fontWeight: 'bold', color: '#4CAF50' }}>
-                —
-              </Typography>
-              <Typography variant="body2" color="text.secondary">
-                Not yet implemented
-              </Typography>
-            </CardContent>
-          </Card>
-        </Grid>
-
-        <Grid item xs={12} md={4}>
-          <Card sx={{ borderRadius: 2 }}>
-            <CardContent sx={{ p: 3, textAlign: 'center' }}>
-              <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'center', mb: 2 }}>
-                <Shield size={24} color="#FF6B35" style={{ marginRight: 8 }} />
-                <Typography variant="h6" sx={{ fontWeight: 'bold' }}>
-                  Security Score
-                </Typography>
-              </Box>
-              <Typography variant="h3" sx={{ fontWeight: 'bold', color: '#4CAF50' }}>
-                —
-              </Typography>
-              <Typography variant="body2" color="text.secondary">
-                Based on security headers
-              </Typography>
-            </CardContent>
-          </Card>
-        </Grid>
+        {metrics.map((metric, index) => {
+          const IconComponent = metric.icon;
+          return (
+            <Grid item xs={12} sm={6} md={4} key={index}>
+              <Card sx={{ height: '100%', borderRadius: 2 }}>
+                <CardContent sx={{ p: 3 }}>
+                  <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'center', mb: 2 }}>
+                    <IconComponent size={24} color="#FF6B35" style={{ marginRight: 8 }} />
+                    <Typography variant="h6" sx={{ fontWeight: 'bold' }}>
+                      {metric.title}
+                    </Typography>
+                  </Box>
+                  <Typography
+                    variant={metric.title === 'Performance Score' ? 'h2' : 'h3'}
+                    sx={{ fontWeight: 'bold', color: metric.color, textAlign: 'center' }}
+                  >
+                    {metric.value}
+                  </Typography>
+                  <Typography variant="body2" color="text.secondary" sx={{ textAlign: 'center' }}>
+                    {metric.description}
+                  </Typography>
+                </CardContent>
+              </Card>
+            </Grid>
+          );
+        })}
       </Grid>
 
       {/* Core Web Vitals Section */}


### PR DESCRIPTION
## Summary
- refactor `PerformanceTab` metric cards to match OverviewTab's auto layout
- remove unused `ResponsiveContainer` import

## Testing
- `npm run test`

------
https://chatgpt.com/codex/tasks/task_e_684a814717cc832b8c587ca92e56d8cb