### PR TITLE
Fix dashboard container width and layout

### DIFF
--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -14,8 +14,8 @@ const Dashboard = ({ darkMode, toggleDarkMode }: DashboardProps) => {
   return (
     <Box>
       <AppHeader darkMode={darkMode} toggleDarkMode={toggleDarkMode} />
-      <Container maxWidth="xl" sx={{ mt: 4, mb: 4 }}>
-        <Box sx={{ display: 'flex', flexDirection: 'column', alignItems: 'center', mb: 4 }}>
+      <Container maxWidth={false} disableGutters sx={{ mt: 4, mb: 4 }}>
+        <Box sx={{ display: 'flex', flexDirection: 'column', alignItems: 'stretch', mb: 4 }}>
           <URLInputForm />
         </Box>
         <DashboardContent />


### PR DESCRIPTION
## Summary
- remove container gutters on Dashboard to allow full-width layout
- allow dashboard header area to stretch to full width

## Testing
- `npm test`
- `npm run build` *(fails: vite not found)*
- `npm run dev` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c2ca21cd4832baa428c999aa15c7e