### PR TITLE
Fix UIAnalysisTab panel width

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1,8 +1,9 @@
 #root {
-  max-width: 1280px;
+  max-width: none !important;
+  width: 100% !important;
   margin: 0 auto;
   padding: 2rem;
-  text-align: center;
+  text-align: left;
 }
 
 .logo {

--- a/src/components/dashboard/UIAnalysisTab.tsx
+++ b/src/components/dashboard/UIAnalysisTab.tsx
@@ -48,8 +48,8 @@ const UIAnalysisTab: React.FC<UIAnalysisTabProps> = ({ data, loading, error }) =
 
       <Grid container spacing={2} alignItems="stretch">
         {/* Color Extraction */}
-        <Grid item xs={12} sx={{ display: 'flex', width: '100%' }}>
-          <Card sx={{ borderRadius: 2, flexGrow: 1, width: '100%' }}>
+        <Grid item xs={12}>
+          <Card sx={{ borderRadius: 2, flexGrow: 1 }}>
             <CardContent sx={{ p: 3 }}>
               <ColorExtractionCard colors={colors} />
             </CardContent>
@@ -57,8 +57,8 @@ const UIAnalysisTab: React.FC<UIAnalysisTabProps> = ({ data, loading, error }) =
         </Grid>
 
         {/* Font Analysis */}
-        <Grid item xs={12} md={6} sx={{ display: 'flex', width: '100%' }}>
-          <Card sx={{ borderRadius: 2, flexGrow: 1, width: '100%' }}>
+        <Grid item xs={12} md={6}>
+          <Card sx={{ borderRadius: 2, flexGrow: 1 }}>
             <CardContent sx={{ p: 3 }}>
               <FontAnalysisCard fonts={fonts} />
             </CardContent>
@@ -66,8 +66,8 @@ const UIAnalysisTab: React.FC<UIAnalysisTabProps> = ({ data, loading, error }) =
         </Grid>
 
         {/* Contrast Warnings */}
-        <Grid item xs={12} md={6} sx={{ display: 'flex', width: '100%' }}>
-          <Card sx={{ borderRadius: 2, flexGrow: 1, width: '100%' }}>
+        <Grid item xs={12} md={6}>
+          <Card sx={{ borderRadius: 2, flexGrow: 1 }}>
             <CardContent sx={{ p: 3 }}>
               <ContrastWarningsCard issues={data.data.ui.contrastIssues} />
             </CardContent>
@@ -75,8 +75,8 @@ const UIAnalysisTab: React.FC<UIAnalysisTabProps> = ({ data, loading, error }) =
         </Grid>
 
         {/* Image Analysis */}
-        <Grid item xs={12} sx={{ display: 'flex', width: '100%' }}>
-          <Card sx={{ borderRadius: 2, flexGrow: 1, width: '100%' }}>
+        <Grid item xs={12}>
+          <Card sx={{ borderRadius: 2, flexGrow: 1 }}>
             <CardContent sx={{ p: 3 }}>
               <ImageAnalysisCard
                 images={images}

--- a/src/components/ui/tabs.tsx
+++ b/src/components/ui/tabs.tsx
@@ -42,9 +42,10 @@ const TabsContent = React.forwardRef<
   <TabsPrimitive.Content
     ref={ref}
     className={cn(
-      "mt-2 ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
+      "mt-2 w-full ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2",
       className
     )}
+    style={{ display: "flex", flex: 1, width: "100%" }}
     {...props}
   />
 ))


### PR DESCRIPTION
## Summary
- remove width cap on `#root`
- ensure tabs expand full width
- adjust UIAnalysisTab grid and cards

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684c363d666c832b8e55bbde31e23a0a