### PR TITLE
Fix Grid2 imports

### DIFF
--- a/src/components/dashboard/ComplianceTab.tsx
+++ b/src/components/dashboard/ComplianceTab.tsx
@@ -1,6 +1,7 @@
 
 import React from 'react';
-import { Box, Typography, Card, CardContent, Alert, CircularProgress, Chip, Grid2 } from '@mui/material';
+import Grid2 from '@mui/material/Unstable_Grid2';
+import { Box, Typography, Card, CardContent, Alert, CircularProgress, Chip } from '@mui/material';
 import type { AnalysisResponse } from '@/types/analysis';
 import { dashIfEmpty } from '../../lib/ui';
 

--- a/src/components/dashboard/ContentAnalysisTab.tsx
+++ b/src/components/dashboard/ContentAnalysisTab.tsx
@@ -1,6 +1,7 @@
 
 import React from 'react';
-import { Box, Typography, Card, CardContent, LinearProgress, Grid2 } from '@mui/material';
+import Grid2 from '@mui/material/Unstable_Grid2';
+import { Box, Typography, Card, CardContent, LinearProgress } from '@mui/material';
 import { ChartContainer, ChartTooltip, ChartTooltipContent } from '../ui/chart';
 import { PieChart, Pie, Cell, ResponsiveContainer, BarChart, Bar, XAxis, YAxis } from 'recharts';
 

--- a/src/components/dashboard/OverviewTab.tsx
+++ b/src/components/dashboard/OverviewTab.tsx
@@ -1,6 +1,7 @@
 
 import React from 'react';
-import { Box, Typography, Card, CardContent, CircularProgress, Alert, Link, IconButton, Popover, Grid2 } from '@mui/material';
+import Grid2 from '@mui/material/Unstable_Grid2';
+import { Box, Typography, Card, CardContent, CircularProgress, Alert, Link, IconButton, Popover } from '@mui/material';
 import { TrendingUp, Users, Clock, Star } from 'lucide-react';
 import InfoOutlined from '@mui/icons-material/InfoOutlined';
 import type { AnalysisResponse } from '@/types/analysis';

--- a/src/components/dashboard/PerformanceTab.tsx
+++ b/src/components/dashboard/PerformanceTab.tsx
@@ -1,5 +1,6 @@
 
 import React from 'react';
+import Grid2 from '@mui/material/Unstable_Grid2';
 import {
   Box,
   Typography,
@@ -8,8 +9,7 @@ import {
   LinearProgress,
   CircularProgress,
   Alert,
-  Chip,
-  Grid2
+  Chip
 } from '@mui/material';
 import { ChartContainer, ChartTooltip, ChartTooltipContent } from '../ui/chart';
 import { BarChart, Bar, XAxis, YAxis } from 'recharts';

--- a/src/components/dashboard/SEOAnalysisTab.tsx
+++ b/src/components/dashboard/SEOAnalysisTab.tsx
@@ -1,6 +1,7 @@
 
 import React from 'react';
-import { Box, Typography, Card, CardContent, Chip, CircularProgress, Alert, Grid2 } from '@mui/material';
+import Grid2 from '@mui/material/Unstable_Grid2';
+import { Box, Typography, Card, CardContent, Chip, CircularProgress, Alert } from '@mui/material';
 import { CheckCircle, AlertCircle, XCircle } from 'lucide-react';
 import type { AnalysisResponse } from '@/types/analysis';
 

--- a/src/components/dashboard/TechTab.tsx
+++ b/src/components/dashboard/TechTab.tsx
@@ -1,6 +1,7 @@
 
 import React from 'react';
-import { Box, Typography, Card, CardContent, Chip, CircularProgress, Alert, Grid2 } from '@mui/material';
+import Grid2 from '@mui/material/Unstable_Grid2';
+import { Box, Typography, Card, CardContent, Chip, CircularProgress, Alert } from '@mui/material';
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '../ui/table';
 import { Shield, Globe, Server, Database, Code, Layers, Zap, Activity, BarChart } from 'lucide-react';
 import type { AnalysisResponse } from '@/types/analysis';

--- a/src/components/dashboard/UIAnalysisTab.tsx
+++ b/src/components/dashboard/UIAnalysisTab.tsx
@@ -1,6 +1,7 @@
 
 import React from 'react';
-import { Box, Typography, Card, CardContent, CircularProgress, Alert, Grid2 } from '@mui/material';
+import Grid2 from '@mui/material/Unstable_Grid2';
+import { Box, Typography, Card, CardContent, CircularProgress, Alert } from '@mui/material';
 import type { AnalysisResponse } from '@/types/analysis';
 import ColorExtractionCard from './ui-analysis/ColorExtractionCard';
 import FontAnalysisCard from './ui-analysis/FontAnalysisCard';

--- a/src/components/dashboard/ui-analysis/ColorExtractionCard.tsx
+++ b/src/components/dashboard/ui-analysis/ColorExtractionCard.tsx
@@ -1,6 +1,7 @@
 
 import React, { useState } from 'react';
-import { Box, Typography, Collapse, IconButton, Unstable_Grid2 as Grid2 } from '@mui/material';
+import Grid2 from '@mui/material/Unstable_Grid2';
+import { Box, Typography, Collapse, IconButton } from '@mui/material';
 import { Palette, ChevronDown, ChevronUp } from 'lucide-react';
 import type { AnalysisResponse } from '@/types/analysis';
 import { groupByFrequency } from '@/lib/ui';


### PR DESCRIPTION
## Summary
- update Grid2 imports to use `@mui/material/Unstable_Grid2`

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d1ea43630832b846084e4d650bac1