### PR TITLE
Unify border styling for analysis sections

### DIFF
--- a/src/components/dashboard/PerformanceTab.tsx
+++ b/src/components/dashboard/PerformanceTab.tsx
@@ -176,7 +176,7 @@ function SecurityHeadersSection({ securityHeaders }: { securityHeaders: Analysis
           {Object.entries(securityHeaders).map(([key, value]) => (
             <Box key={key} sx={{
               p: 2,
-              border: '1px solid #E0E0E0',
+              border: '1px solid rgba(0,0,0,0.1)',
               borderRadius: 1,
               display: 'flex',
               justifyContent: 'space-between',
@@ -216,7 +216,8 @@ function RecommendationsSection({ recommendations }: { recommendations: Analysis
               p: 2,
               backgroundColor: rec.type === 'warning' ? '#FFF3E0' : rec.type === 'error' ? '#FFEBEE' : '#E8F5E8',
               borderRadius: 1,
-              mb: 2
+              mb: 2,
+              border: '1px solid rgba(0,0,0,0.1)'
             }}>
               <Typography variant="subtitle2" sx={{
                 fontWeight: 'bold',


### PR DESCRIPTION
## Summary
- use the same border color as TechStack for Security Headers boxes
- add matching border to Performance Recommendations

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684f86132434832b9e6f3379f5dc3f81