### PR TITLE
Enhance compliance other checks styling

### DIFF
--- a/src/components/dashboard/ComplianceTab.tsx
+++ b/src/components/dashboard/ComplianceTab.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { Box, Typography, Card, CardContent, Alert, CircularProgress, Chip } from '@mui/material';
+import { Box, Typography, Card, CardContent, Alert, CircularProgress, Chip, Tooltip } from '@mui/material';
+import { useTheme } from '@mui/material/styles';
 import type { AnalysisResponse } from '@/types/analysis';
 import { dashIfEmpty } from '../../lib/ui';
 import LegendContainer from './LegendContainer';
@@ -10,7 +11,31 @@ interface ComplianceTabProps {
   error: string | null;
 }
 
+function chipStateStyle(isActive: boolean, theme: any) {
+  return isActive
+    ? {
+        variant: 'outlined' as const,
+        sx: {
+          borderColor: theme.palette.success.main,
+          color: theme.palette.success.main,
+          background: 'transparent',
+          fontWeight: 600,
+        },
+      }
+    : {
+        variant: 'outlined' as const,
+        color: 'default' as const,
+        sx: {
+          borderColor: theme.palette.grey[400],
+          color: theme.palette.grey[400],
+          background: 'transparent',
+          fontWeight: 600,
+        },
+      };
+}
+
 const ComplianceTab: React.FC<ComplianceTabProps> = ({ data, loading, error }) => {
+  const theme = useTheme();
   if (loading) {
     return (
       <Box sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center', py: 8 }}>
@@ -93,12 +118,78 @@ const ComplianceTab: React.FC<ComplianceTabProps> = ({ data, loading, error }) =
                 Other Checks
               </Typography>
               <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 1, mb: 2 }}>
-                <Chip label={`Open Graph: ${social.hasOpenGraph ? 'yes' : dashIfEmpty('')}` } />
-                <Chip label={`Twitter Card: ${social.hasTwitterCard ? 'yes' : dashIfEmpty('')}` } />
-                <Chip label={`Share Buttons: ${social.hasShareButtons ? 'yes' : dashIfEmpty('')}` } />
-                <Chip label={`Cookie Script: ${cookies.hasCookieScript ? 'yes' : dashIfEmpty('')}` } />
-                <Chip label={`CSS Minified: ${minify.cssMinified ? 'yes' : dashIfEmpty('')}` } />
-                <Chip label={`JS Minified: ${minify.jsMinified ? 'yes' : dashIfEmpty('')}` } />
+                <Tooltip
+                  title={social.hasOpenGraph ? 'Open Graph tags detected' : 'Open Graph tags missing'}
+                  enterDelay={300}
+                  enterTouchDelay={300}
+                >
+                  <Chip
+                    label="Open Graph"
+                    {...chipStateStyle(Boolean(social.hasOpenGraph), theme)}
+                    size="small"
+                    sx={{ cursor: 'help', ...chipStateStyle(Boolean(social.hasOpenGraph), theme).sx }}
+                  />
+                </Tooltip>
+                <Tooltip
+                  title={social.hasTwitterCard ? 'Twitter card tags detected' : 'Twitter card tags missing'}
+                  enterDelay={300}
+                  enterTouchDelay={300}
+                >
+                  <Chip
+                    label="Twitter Card"
+                    {...chipStateStyle(Boolean(social.hasTwitterCard), theme)}
+                    size="small"
+                    sx={{ cursor: 'help', ...chipStateStyle(Boolean(social.hasTwitterCard), theme).sx }}
+                  />
+                </Tooltip>
+                <Tooltip
+                  title={social.hasShareButtons ? 'Share buttons found' : 'Share buttons not found'}
+                  enterDelay={300}
+                  enterTouchDelay={300}
+                >
+                  <Chip
+                    label="Share Buttons"
+                    {...chipStateStyle(Boolean(social.hasShareButtons), theme)}
+                    size="small"
+                    sx={{ cursor: 'help', ...chipStateStyle(Boolean(social.hasShareButtons), theme).sx }}
+                  />
+                </Tooltip>
+                <Tooltip
+                  title={cookies.hasCookieScript ? 'Cookie consent script detected' : 'No cookie script found'}
+                  enterDelay={300}
+                  enterTouchDelay={300}
+                >
+                  <Chip
+                    label="Cookie Script"
+                    {...chipStateStyle(Boolean(cookies.hasCookieScript), theme)}
+                    size="small"
+                    sx={{ cursor: 'help', ...chipStateStyle(Boolean(cookies.hasCookieScript), theme).sx }}
+                  />
+                </Tooltip>
+                <Tooltip
+                  title={minify.cssMinified ? 'CSS files are minified' : 'CSS files are not minified'}
+                  enterDelay={300}
+                  enterTouchDelay={300}
+                >
+                  <Chip
+                    label="CSS Minified"
+                    {...chipStateStyle(Boolean(minify.cssMinified), theme)}
+                    size="small"
+                    sx={{ cursor: 'help', ...chipStateStyle(Boolean(minify.cssMinified), theme).sx }}
+                  />
+                </Tooltip>
+                <Tooltip
+                  title={minify.jsMinified ? 'JavaScript files are minified' : 'JavaScript files are not minified'}
+                  enterDelay={300}
+                  enterTouchDelay={300}
+                >
+                  <Chip
+                    label="JS Minified"
+                    {...chipStateStyle(Boolean(minify.jsMinified), theme)}
+                    size="small"
+                    sx={{ cursor: 'help', ...chipStateStyle(Boolean(minify.jsMinified), theme).sx }}
+                  />
+                </Tooltip>
               </Box>
               <Typography variant="body2">
                 <strong>Broken Links:</strong> {links.brokenLinks.length || 0}


### PR DESCRIPTION
## Summary
- color-code compliance checks using theme palette
- add tooltips for each check indicator

## Testing
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_684f8e2b1758832bbb178ac0235406c8