### PR TITLE
Adjust URL font size on Overview

### DIFF
--- a/src/components/dashboard/OverviewTab.tsx
+++ b/src/components/dashboard/OverviewTab.tsx
@@ -331,7 +331,7 @@ const OverviewTab: React.FC<OverviewTabProps> = ({ data, loading, error }) => {
           <Typography
             variant="caption"
             sx={{
-              fontSize: { xs: '0.7rem', sm: '0.75rem' },
+              fontSize: { xs: '0.8rem', sm: '0.85rem' },
               color: 'text.secondary',
               overflow: 'hidden',
               textOverflow: 'ellipsis',


### PR DESCRIPTION
## Summary
- boost font size for the analyzed URL on the Overview page

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684f9ce91e18832b95b481defc96a768