### PR TITLE
Lift hero section content

### DIFF
--- a/src/components/AppHeader.tsx
+++ b/src/components/AppHeader.tsx
@@ -56,14 +56,14 @@ const AppHeader = ({ darkMode, toggleDarkMode }: { darkMode: boolean; toggleDark
           backgroundColor: darkMode ? 'rgba(0, 0, 0, 0.8)' : 'rgba(255, 255, 255, 0.8)',
           boxShadow: darkMode ? '0 8px 32px rgba(0, 0, 0, 0.3)' : '0 8px 32px rgba(0, 0, 0, 0.1)',
           color: darkMode ? '#FFFFFF' : '#000000',
-          // Reduce header height
-          minHeight: { xs: 48, md: 56 },
+          // Further reduce header height so hero content can sit higher
+          minHeight: { xs: 40, md: 48 },
         }}
       >
         <Toolbar
           sx={{
-            // Reduce toolbar height
-            minHeight: { xs: 48, md: 56 },
+            // Reduce toolbar height to match the smaller header
+            minHeight: { xs: 40, md: 48 },
             px: { xs: 2, md: 3 },
           }}
         >
@@ -108,10 +108,10 @@ const AppHeader = ({ darkMode, toggleDarkMode }: { darkMode: boolean; toggleDark
         </Toolbar>
       </AppBar>
 
-      {/* Reduce the spacing toolbar height to match the reduced header */}
-      <Toolbar 
+      {/* Reduce the spacing toolbar height to match the further reduced header */}
+      <Toolbar
         sx={{
-          minHeight: { xs: 48, md: 56 },
+          minHeight: { xs: 40, md: 48 },
         }}
       />
     </>

--- a/src/components/HeroSection.tsx
+++ b/src/components/HeroSection.tsx
@@ -111,8 +111,9 @@ const HeroSection = () => {
         alignItems: 'center',
         position: 'relative',
         overflow: 'hidden',
-        // Reduce top/bottom padding to fit more content
-        py: { xs: 1, md: 2 },
+        // Reduce top padding further so the hero sits higher
+        pt: { xs: 0.5, sm: 0.75, md: 1, lg: 1.25 },
+        pb: { xs: 1, sm: 1.5, md: 2, lg: 2.5 },
       }}
     >
       {/* Gradient + mask background applied absolutely below content */}
@@ -203,9 +204,9 @@ const HeroSection = () => {
         <Box
           sx={{
             textAlign: 'center',
-            // Further reduce padding, especially top padding
-            py: { xs: 2, md: 3 },
-            pt: { xs: 1, md: 2 },
+            // Move content higher by cutting the top padding in half
+            pb: { xs: 2, sm: 2.5, md: 3, lg: 3.5 },
+            pt: { xs: 0.5, sm: 0.75, md: 1, lg: 1.25 },
             display: 'flex',
             flexDirection: 'column',
             alignItems: 'center',


### PR DESCRIPTION
## Summary
- move hero section closer to the top of the page by lowering padding
- expand responsive padding breakpoints for more screen sizes
- reduce header and toolbar heights so hero sits higher

## Testing
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_6850a5dad88c832b8de115e986dfcef6