### PR TITLE
Auto-collapse color extraction sections

### DIFF
--- a/src/components/dashboard/ui-analysis/ColorExtractionCard.tsx
+++ b/src/components/dashboard/ui-analysis/ColorExtractionCard.tsx
@@ -149,6 +149,21 @@ const ColorExtractionCard: React.FC<ColorExtractionCardProps> = ({ colors }) => 
       initialExpanded[group.name] = true;
     });
     setExpandedSections(initialExpanded);
+
+    // Collapse sections other than "Background" after a delay
+    const timer = setTimeout(() => {
+      setExpandedSections(prev => {
+        const updated: Record<string, boolean> = { ...prev };
+        Object.keys(updated).forEach(name => {
+          if (name !== 'Background') {
+            updated[name] = false;
+          }
+        });
+        return updated;
+      });
+    }, 2500);
+
+    return () => clearTimeout(timer);
   }, [colors]);
 
   return (


### PR DESCRIPTION
## Summary
- collapse color extraction sections after `Background`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6851f975a308832bac2e7974a4eefde2