### PR TITLE
fix collapsible ui state

### DIFF
--- a/src/components/dashboard/ui-analysis/ColorExtractionCard.tsx
+++ b/src/components/dashboard/ui-analysis/ColorExtractionCard.tsx
@@ -1,8 +1,9 @@
-import React, { useState } from 'react';
+import React from 'react';
 import { Box, Typography, Collapse, IconButton } from '@mui/material';
 import { Palette, ChevronDown, ChevronUp } from 'lucide-react';
 import type { AnalysisResponse } from '@/types/analysis';
 import { groupByFrequency } from '@/lib/ui';
+import { usePersistentState } from '@/hooks/usePersistentState';
 
 interface ColorExtractionCardProps {
   colors: AnalysisResponse['data']['ui']['colors'];
@@ -24,7 +25,10 @@ interface UsageGroup {
 }
 
 const ColorExtractionCard: React.FC<ColorExtractionCardProps> = ({ colors }) => {
-  const [expandedSections, setExpandedSections] = useState<Record<string, boolean>>({});
+  const [expandedSections, setExpandedSections] = usePersistentState<Record<string, boolean>>(
+    'ui-color-extraction-expanded',
+    {}
+  );
 
   const toggleSection = (sectionName: string) => {
     setExpandedSections(prev => ({
@@ -142,28 +146,39 @@ const ColorExtractionCard: React.FC<ColorExtractionCardProps> = ({ colors }) => 
 
   const usageGroups = groupByUsage();
 
-  // Initialize all sections as expanded
+  // Initialize sections when colors change, but respect any stored state
   React.useEffect(() => {
-    const initialExpanded: Record<string, boolean> = {};
-    usageGroups.forEach(group => {
-      initialExpanded[group.name] = true;
-    });
-    setExpandedSections(initialExpanded);
-
-    // Collapse sections other than "Background" after a delay
-    const timer = setTimeout(() => {
-      setExpandedSections(prev => {
-        const updated: Record<string, boolean> = { ...prev };
-        Object.keys(updated).forEach(name => {
-          if (name !== 'Background') {
-            updated[name] = false;
-          }
-        });
-        return updated;
+    const hadStoredState = Object.keys(expandedSections).length > 0;
+    let hasNewSection = false;
+    setExpandedSections(prev => {
+      const updated = { ...prev };
+      usageGroups.forEach(group => {
+        if (!(group.name in updated)) {
+          updated[group.name] = true;
+          hasNewSection = true;
+        }
       });
-    }, 2500);
+      return updated;
+    });
 
-    return () => clearTimeout(timer);
+    let timer: NodeJS.Timeout | undefined;
+    if (!hadStoredState && hasNewSection) {
+      timer = setTimeout(() => {
+        setExpandedSections(prev => {
+          const updated: Record<string, boolean> = { ...prev };
+          Object.keys(updated).forEach(name => {
+            if (name !== 'Background') {
+              updated[name] = false;
+            }
+          });
+          return updated;
+        });
+      }, 2500);
+    }
+
+    return () => {
+      if (timer) clearTimeout(timer);
+    };
   }, [colors]);
 
   return (

--- a/src/components/dashboard/ui-analysis/ImageAnalysisCard.tsx
+++ b/src/components/dashboard/ui-analysis/ImageAnalysisCard.tsx
@@ -1,8 +1,9 @@
 
-import React, { useState } from 'react';
+import React from 'react';
 import { Box, Typography, List, ListItem, Link, Collapse, IconButton } from '@mui/material';
 import { Image, ChevronDown, ChevronUp } from 'lucide-react';
 import type { AnalysisResponse } from '@/types/analysis';
+import { usePersistentState } from '@/hooks/usePersistentState';
 
 interface ImageAnalysisCardProps {
   images: AnalysisResponse['data']['ui']['images'];
@@ -17,11 +18,14 @@ interface ImageAnalysisCardProps {
 }
 
 const ImageAnalysisCard: React.FC<ImageAnalysisCardProps> = ({ images, imageAnalysis }) => {
-  const [expandedSections, setExpandedSections] = useState<Record<string, boolean>>({
-    total: false,
-    photos: false,
-    icons: false
-  });
+  const [expandedSections, setExpandedSections] = usePersistentState<Record<string, boolean>>(
+    'ui-image-analysis-expanded',
+    {
+      total: false,
+      photos: false,
+      icons: false
+    }
+  );
 
   const toggleSection = (name: string) => {
     setExpandedSections(prev => ({

--- a/src/hooks/usePersistentState.ts
+++ b/src/hooks/usePersistentState.ts
@@ -1,0 +1,29 @@
+import { useState, useEffect } from 'react';
+
+/**
+ * Persist state to localStorage so it survives component unmounts.
+ * @param key Unique storage key
+ * @param defaultValue Default value when nothing is stored
+ */
+export function usePersistentState<T>(key: string, defaultValue: T) {
+  const [value, setValue] = useState<T>(() => {
+    if (typeof window === 'undefined') return defaultValue;
+    try {
+      const stored = window.localStorage.getItem(key);
+      return stored ? (JSON.parse(stored) as T) : defaultValue;
+    } catch (err) {
+      console.error('Failed to load persistent state', err);
+      return defaultValue;
+    }
+  });
+
+  useEffect(() => {
+    try {
+      window.localStorage.setItem(key, JSON.stringify(value));
+    } catch (err) {
+      console.error('Failed to save persistent state', err);
+    }
+  }, [key, value]);
+
+  return [value, setValue] as const;
+}


### PR DESCRIPTION
## Summary
- add `usePersistentState` hook for localStorage state
- keep UI tab sections expanded state when switching tabs

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6851fbf2881c832bb7daca69346e85e3