### PR TITLE
Remember UI tab state within session

### DIFF
--- a/src/components/dashboard/ui-analysis/ColorExtractionCard.tsx
+++ b/src/components/dashboard/ui-analysis/ColorExtractionCard.tsx
@@ -3,7 +3,7 @@ import { Box, Typography, Collapse, IconButton } from '@mui/material';
 import { Palette, ChevronDown, ChevronUp } from 'lucide-react';
 import type { AnalysisResponse } from '@/types/analysis';
 import { groupByFrequency } from '@/lib/ui';
-import { usePersistentState } from '@/hooks/usePersistentState';
+import { useSessionState } from '@/hooks/useSessionState';
 
 interface ColorExtractionCardProps {
   colors: AnalysisResponse['data']['ui']['colors'];
@@ -25,7 +25,7 @@ interface UsageGroup {
 }
 
 const ColorExtractionCard: React.FC<ColorExtractionCardProps> = ({ colors }) => {
-  const [expandedSections, setExpandedSections] = usePersistentState<Record<string, boolean>>(
+  const [expandedSections, setExpandedSections] = useSessionState<Record<string, boolean>>(
     'ui-color-extraction-expanded',
     {}
   );

--- a/src/components/dashboard/ui-analysis/ImageAnalysisCard.tsx
+++ b/src/components/dashboard/ui-analysis/ImageAnalysisCard.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import { Box, Typography, List, ListItem, Link, Collapse, IconButton } from '@mui/material';
 import { Image, ChevronDown, ChevronUp } from 'lucide-react';
 import type { AnalysisResponse } from '@/types/analysis';
-import { usePersistentState } from '@/hooks/usePersistentState';
+import { useSessionState } from '@/hooks/useSessionState';
 
 interface ImageAnalysisCardProps {
   images: AnalysisResponse['data']['ui']['images'];
@@ -18,7 +18,7 @@ interface ImageAnalysisCardProps {
 }
 
 const ImageAnalysisCard: React.FC<ImageAnalysisCardProps> = ({ images, imageAnalysis }) => {
-  const [expandedSections, setExpandedSections] = usePersistentState<Record<string, boolean>>(
+  const [expandedSections, setExpandedSections] = useSessionState<Record<string, boolean>>(
     'ui-image-analysis-expanded',
     {
       total: false,

--- a/src/hooks/useSessionState.ts
+++ b/src/hooks/useSessionState.ts
@@ -1,0 +1,29 @@
+import { useState, useEffect } from 'react';
+
+/**
+ * Persist state to sessionStorage so it survives component unmounts within the same tab session.
+ * @param key Unique storage key
+ * @param defaultValue Default value when nothing is stored
+ */
+export function useSessionState<T>(key: string, defaultValue: T) {
+  const [value, setValue] = useState<T>(() => {
+    if (typeof window === 'undefined') return defaultValue;
+    try {
+      const stored = window.sessionStorage.getItem(key);
+      return stored ? (JSON.parse(stored) as T) : defaultValue;
+    } catch (err) {
+      console.error('Failed to load session state', err);
+      return defaultValue;
+    }
+  });
+
+  useEffect(() => {
+    try {
+      window.sessionStorage.setItem(key, JSON.stringify(value));
+    } catch (err) {
+      console.error('Failed to save session state', err);
+    }
+  }, [key, value]);
+
+  return [value, setValue] as const;
+}


### PR DESCRIPTION
## Summary
- create `useSessionState` hook to store state in sessionStorage
- update UI analysis cards to use the new hook

## Testing
- `npm run test`
- `npx tsc -p tsconfig.json --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_68522b47eadc832b8413927f65dca6d0