### PR TITLE
Fix header gradient width

### DIFF
--- a/src/components/AppHeader.tsx
+++ b/src/components/AppHeader.tsx
@@ -78,16 +78,21 @@ const AppHeader = ({ darkMode, toggleDarkMode }: { darkMode: boolean; toggleDark
             sx={{
               flexGrow: 1,
               fontWeight: 700,
-              background: 'linear-gradient(45deg, #FF6B35 30%, #0984E3 90%)',
-              backgroundClip: 'text',
-              WebkitBackgroundClip: 'text',
-              WebkitTextFillColor: 'transparent',
               textDecoration: 'none',
               // Slightly reduce font size
               fontSize: { xs: '1.1rem', md: '1.25rem' },
             }}
           >
-            SiteDeconstructor
+            <span
+              style={{
+                background: 'linear-gradient(45deg, #FF6B35 30%, #0984E3 90%)',
+                WebkitBackgroundClip: 'text',
+                color: 'transparent',
+                display: 'inline-block',
+              }}
+            >
+              SiteDeconstructor
+            </span>
           </Typography>
 
           {!isMobile && (


### PR DESCRIPTION
## Summary
- ensure the header logo gradient is bounded to its text

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6856b656a19c832bb01b61db6e76e2f6