### PR TITLE
Fix overlapping chips in ComplianceTab

### DIFF
--- a/src/components/dashboard/ComplianceTab.tsx
+++ b/src/components/dashboard/ComplianceTab.tsx
@@ -12,7 +12,6 @@ import {
   Tooltip,
   Collapse,
   IconButton,
-  Badge,
 } from '@mui/material';
 import { ChevronDown, ChevronUp, Shield } from 'lucide-react';
 import type { AnalysisResponse } from '@/types/analysis';
@@ -127,13 +126,16 @@ const ComplianceTab: React.FC<ComplianceTabProps> = ({ data, loading, error }) =
                 </Typography>
               </Box>
               <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, ml: 2 }}>
-                <Badge
-                  badgeContent={headersDetected}
-                  color="primary"
+                <Chip
+                  label={`${headersDetected} of ${securityEntries.length}`}
+                  variant="outlined"
+                  size="small"
                   sx={{
-                    '& .MuiBadge-badge': {
-                      backgroundColor: getSecurityScoreColor(securityScore),
-                    },
+                    borderColor: getSecurityScoreColor(securityScore),
+                    color: getSecurityScoreColor(securityScore),
+                    backgroundColor: `${getSecurityScoreColor(securityScore)}20`,
+                    fontWeight: 600,
+                    mr: 1,
                   }}
                 />
                 <Chip


### PR DESCRIPTION
## Summary
- remove unused Badge import
- replace Badge with Chip displaying detected headers count
- apply margin to first chip so chips no longer overlap

## Testing
- `npm test`
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685768a7966c832bb4265aa7ac6fe811