### PR TITLE
Fix metric card header line break on mobile only

### DIFF
--- a/src/components/dashboard/overview/MetricCard.tsx
+++ b/src/components/dashboard/overview/MetricCard.tsx
@@ -56,7 +56,10 @@ const MetricCard: React.FC<MetricCardProps> = ({
             }}
             data-testid="card-title"
           >
-            {titleLines[0]}<br />{titleLines[1]}
+            {titleLines[0]}
+            <span className="hidden sm:inline"> </span>
+            <br className="sm:hidden" />
+            {titleLines[1]}
           </Typography>
           {/* Always render a placeholder IconButton for alignment (real or invisible) */}
           {info && onInfo ? (


### PR DESCRIPTION
## Summary
- adjust MetricCard header line break to only show on small screens

## Testing
- `npm run test`
- `npx tsc -p tsconfig.json --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_6857b9c23474832b990867bce00301e6