### PR TITLE
Fix chip overlap in ComplianceTab

### DIFF
--- a/src/components/dashboard/ComplianceTab.tsx
+++ b/src/components/dashboard/ComplianceTab.tsx
@@ -131,6 +131,7 @@ const ComplianceTab: React.FC<ComplianceTabProps> = ({ data, loading, error }) =
                   badgeContent={headersDetected}
                   color="primary"
                   sx={{
+                    mr: 1,
                     '& .MuiBadge-badge': {
                       backgroundColor: getSecurityScoreColor(securityScore),
                     },


### PR DESCRIPTION
## Summary
- restore Badge import and usage for detected header count
- add right margin to Badge to prevent overlap with score Chip

## Testing
- `npm test`
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685768a7966c832bb4265aa7ac6fe811