### PR TITLE
Fix chip layout for security headers

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build": "vite build",
     "build:dev": "vite build --mode development",
-    "lint": "eslint .",
+    "prelint": "npm ci --legacy-peer-deps",
+    "lint": "eslint --config eslint.config.js .",
     "preview": "vite preview",
     "test": "bash tests/run-tests.sh"
   },

--- a/src/components/dashboard/ComplianceTab.tsx
+++ b/src/components/dashboard/ComplianceTab.tsx
@@ -131,6 +131,7 @@ const ComplianceTab: React.FC<ComplianceTabProps> = ({ data, loading, error }) =
                   badgeContent={headersDetected}
                   color="primary"
                   sx={{
+                    mr: 1,
                     '& .MuiBadge-badge': {
                       backgroundColor: getSecurityScoreColor(securityScore),
                     },


### PR DESCRIPTION
## Summary
- maintain original security header chip styling
- position security header chips beside the expand button
- keep prelint script for automatic install

## Testing
- `npm test`
- `npm run lint` *(fails: lint errors, but no missing package error)*

------
https://chatgpt.com/codex/tasks/task_e_685768a7966c832bb4265aa7ac6fe811