### PR TITLE
Fix URL header link width

### DIFF
--- a/src/components/dashboard/overview/UrlDisplayBox.tsx
+++ b/src/components/dashboard/overview/UrlDisplayBox.tsx
@@ -13,7 +13,8 @@ const UrlDisplayBox: React.FC<UrlDisplayBoxProps> = ({ url }) => {
         display: 'flex',
         alignItems: 'center',
         minWidth: 0,
-        flex: 1,
+        flexBasis: '50%',
+        justifyContent: 'flex-end',
       }}
     >
       <Typography


### PR DESCRIPTION
## Summary
- restrict URL link width in OverviewTab header

## Testing
- `npm run test`
- `npx tsc -p tsconfig.json --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_68581604562c832ba02c79f3ee14c191