### PR TITLE
Separate analysis summary from key findings

### DIFF
--- a/src/components/dashboard/OverviewTab.tsx
+++ b/src/components/dashboard/OverviewTab.tsx
@@ -130,13 +130,13 @@ const OverviewTab: React.FC<OverviewTabProps> = ({ data, loading, error }) => {
       <MetricInfoPopover anchorEl={infoAnchor} infoText={infoText} onClose={handleClosePopover} />
 
       <Box sx={{ mt: 4 }}>
-        <Card sx={{ borderRadius: 2 }}>
+        <Card sx={{ borderRadius: 2, mb: 2 }}>
           <CardContent sx={{ p: 3 }}>
             <Box sx={{ display: 'flex', alignItems: 'center', mb: 3 }}>
               <BarChart3 size={24} color="#FF6B35" style={{ marginRight: 8 }} />
-              <Typography 
-                variant="h6" 
-                sx={{ 
+              <Typography
+                variant="h6"
+                sx={{
                   fontWeight: 'bold',
                   fontSize: { xs: '1.1rem', sm: '1.25rem' }
                 }}
@@ -150,20 +150,23 @@ const OverviewTab: React.FC<OverviewTabProps> = ({ data, loading, error }) => {
                 ? ' The page shows excellent performance across most metrics.'
                 : ' The page has room for improvement in several areas.'}
             </Typography>
-            <Typography variant="body1" paragraph>
-              <Box sx={{ display: 'flex', alignItems: 'center', mb: 2 }}>
-                <TrendingUp size={24} color="#FF6B35" style={{ marginRight: 8 }} />
-                <Typography 
-                  variant="h6" 
-                  sx={{ 
-                    fontWeight: 'bold',
-                    fontSize: { xs: '1.1rem', sm: '1.25rem' }
-                  }}
-                >
-                  Key Findings
-                </Typography>
-              </Box>
-            </Typography>
+          </CardContent>
+        </Card>
+
+        <Card sx={{ borderRadius: 2 }}>
+          <CardContent sx={{ p: 3 }}>
+            <Box sx={{ display: 'flex', alignItems: 'center', mb: 2 }}>
+              <TrendingUp size={24} color="#FF6B35" style={{ marginRight: 8 }} />
+              <Typography
+                variant="h6"
+                sx={{
+                  fontWeight: 'bold',
+                  fontSize: { xs: '1.1rem', sm: '1.25rem' }
+                }}
+              >
+                Key Findings
+              </Typography>
+            </Box>
             <KeyFindingsGrid overview={data.data.overview} theme={theme} />
           </CardContent>
         </Card>


### PR DESCRIPTION
## Summary
- split the analysis summary and key findings sections into two cards

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685821132558832b9ddfecbd927e9cb8