### PR TITLE
Fix color name fallback

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -46,7 +46,6 @@
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "cmdk": "^1.0.0",
-        "color-namer": "^1.4.0",
         "date-fns": "^3.6.0",
         "embla-carousel-react": "^8.3.0",
         "fontfaceobserver": "^2.3.0",
@@ -5020,16 +5019,6 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "license": "MIT"
-    },
-    "node_modules/color-namer": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/color-namer/-/color-namer-1.4.0.tgz",
-      "integrity": "sha512-3mQMY9MJyfdV2uhe+xjQWcKHtYnPtl5svGjt89V2WWT2MlaLAd7C02886Wq7H1MTjjIIEa/NJLYPNF/Lhxhq2A==",
-      "license": "MIT",
-      "dependencies": {
-        "chroma-js": "^1.3.4",
-        "es6-weak-map": "^2.0.3"
-      }
     },
     "node_modules/commander": {
       "version": "4.1.1",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,6 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "cmdk": "^1.0.0",
-    "color-namer": "^1.4.0",
     "date-fns": "^3.6.0",
     "embla-carousel-react": "^8.3.0",
     "fontfaceobserver": "^2.3.0",

--- a/supabase/functions/analyze/index.ts
+++ b/supabase/functions/analyze/index.ts
@@ -1,5 +1,5 @@
 import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
-import namer from 'color-namer';
+import namer from 'npm:color-namer@1.4.0';
 
 const corsHeaders = {
   'Access-Control-Allow-Origin': '*',
@@ -17,10 +17,14 @@ function mapScoreToGrade(score: number): string {
 
 // Helper function to get color name
 function getColorName(hex: string): string {
-  // Use the html palette from color-namer
-  const result = namer(hex);
-  const name  = result.html?.[0]?.name;
-  return name && name.toLowerCase() !== hex.toLowerCase() ? name : hex;
+  try {
+    const result = namer(hex);
+    const name = result.ntc?.[0]?.name || result.html?.[0]?.name;
+    return name && name.toLowerCase() !== hex.toLowerCase() ? name : '';
+  } catch (error) {
+    console.error('color-namer failed:', error);
+    return '';
+  }
 }
 
 // ----- BEGIN ORIGINAL extractCssColors -----


### PR DESCRIPTION
## Summary
- rely solely on color-namer when mapping hex colors to names
- return an empty name if color-namer fails

## Testing
- `bash tests/run-tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_68595390b124832b81098793b42c6d2b