### PR TITLE
Fix TypeScript build by including Vite client types

### DIFF
--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -20,6 +20,7 @@
     "noUnusedParameters": false,
     "noImplicitAny": false,
     "noFallthroughCasesInSwitch": false,
+    "types": ["vite/client"],
 
     "baseUrl": ".",
     "paths": {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,7 +17,7 @@
     "moduleResolution": "bundler",
     "baseUrl": ".",
     "types": ["node", "vite/client"],
-    "typeRoots": ["./node_modules/@types", "./node_modules/vite", "./server"],
+    "typeRoots": ["./node_modules/@types", "./node_modules", "./server"],
     "paths": {
       "@/*": ["./client/src/*"],
       "@shared/*": ["./shared/*"]


### PR DESCRIPTION
## Summary
- add Vite client types to the app tsconfig
- adjust root typeRoots to allow resolving `vite/client`

## Testing
- `npx tsc --noEmit` *(fails: Cannot find modules '@mui/icons-material', etc.)*
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685c17db012c832ba12e46b2b8b1ec61