### PR TITLE
Use color-namer for color names

### DIFF
--- a/server/routes.ts
+++ b/server/routes.ts
@@ -3,6 +3,7 @@ import { createServer, type Server } from "http";
 import { storage } from "./storage";
 import Wappalyzer from 'wappalyzer';
 import { createClient } from '@supabase/supabase-js';
+import namer from 'color-namer';
 
 // Helper function to map score to letter grade
 function mapScoreToGrade(score: number): string {
@@ -13,31 +14,14 @@ function mapScoreToGrade(score: number): string {
   return 'F';
 }
 
-// Helper function to get color name
+// Helper function to get color name using color-namer
 function getColorName(hex: string): string {
-  const colorNames: Record<string, string> = {
-    '#FFFFFF': 'White',
-    '#000000': 'Black',
-    '#FF0000': 'Red',
-    '#00FF00': 'Green',
-    '#0000FF': 'Blue',
-    '#FFFF00': 'Yellow',
-    '#FF00FF': 'Magenta',
-    '#00FFFF': 'Cyan',
-    '#808080': 'Gray',
-    '#800000': 'Maroon',
-    '#008000': 'Dark Green',
-    '#000080': 'Navy',
-    '#808000': 'Olive',
-    '#800080': 'Purple',
-    '#008080': 'Teal',
-    '#C0C0C0': 'Silver',
-    '#F5F5F5': 'White Smoke',
-    '#1A1A1A': 'Dark Gray',
-    '#2D2D2D': 'Charcoal',
-    '#333333': 'Dark Charcoal'
-  };
-  return colorNames[hex.toUpperCase()] || hex;
+  try {
+    const result = namer(hex);
+    return result.pantone[0]?.name || result.basic[0]?.name || hex;
+  } catch {
+    return hex;
+  }
 }
 
 // Extract CSS colors from HTML

--- a/supabase/functions/analyze/index.ts
+++ b/supabase/functions/analyze/index.ts
@@ -1,4 +1,5 @@
 import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
+import namer from 'npm:color-namer';
 
 const corsHeaders = {
   'Access-Control-Allow-Origin': '*',
@@ -14,31 +15,14 @@ function mapScoreToGrade(score: number): string {
   return 'F';
 }
 
-// Helper function to get color name
+// Helper function to get color name using color-namer
 function getColorName(hex: string): string {
-  const colorNames: Record<string, string> = {
-    '#FFFFFF': 'White',
-    '#000000': 'Black',
-    '#FF0000': 'Red',
-    '#00FF00': 'Green',
-    '#0000FF': 'Blue',
-    '#FFFF00': 'Yellow',
-    '#FF00FF': 'Magenta',
-    '#00FFFF': 'Cyan',
-    '#808080': 'Gray',
-    '#800000': 'Maroon',
-    '#008000': 'Dark Green',
-    '#000080': 'Navy',
-    '#808000': 'Olive',
-    '#800080': 'Purple',
-    '#008080': 'Teal',
-    '#C0C0C0': 'Silver',
-    '#F5F5F5': 'White Smoke',
-    '#1A1A1A': 'Dark Gray',
-    '#2D2D2D': 'Charcoal',
-    '#333333': 'Dark Charcoal'
-  };
-  return colorNames[hex.toUpperCase()] || hex;
+  try {
+    const result = namer(hex);
+    return result.pantone[0]?.name || result.basic[0]?.name || hex;
+  } catch {
+    return hex;
+  }
 }
 
 // ----- BEGIN ORIGINAL extractCssColors -----


### PR DESCRIPTION
## Summary
- replace custom getColorName helper with `color-namer`
- apply change in both Node server and Supabase function

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685cac363ef0832bbf6f48b7af38c135