### PR TITLE
Improve URL truncation display

### DIFF
--- a/client/src/components/dashboard/overview/UrlDisplayBox.tsx
+++ b/client/src/components/dashboard/overview/UrlDisplayBox.tsx
@@ -1,5 +1,5 @@
 
-import React from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { Box, Typography, Link } from '@mui/material';
 
 interface UrlDisplayBoxProps {
@@ -7,6 +7,51 @@ interface UrlDisplayBoxProps {
 }
 
 const UrlDisplayBox: React.FC<UrlDisplayBoxProps> = ({ url }) => {
+  const [displayUrl, setDisplayUrl] = useState(url);
+  const textRef = useRef<HTMLAnchorElement>(null);
+
+  useEffect(() => {
+    const el = textRef.current;
+    if (!el) return;
+
+    const updateDisplay = () => {
+      if (!el) return;
+      el.textContent = url;
+      if (el.scrollWidth <= el.clientWidth) {
+        if (displayUrl !== url) {
+          setDisplayUrl(url);
+        }
+        return;
+      }
+
+      let start = 0;
+      let end = url.length;
+      let truncated = url;
+
+      while (start < end) {
+        const mid = Math.floor((start + end) / 2);
+        const candidate = `${url.slice(0, mid)}[…]`;
+        el.textContent = candidate;
+        if (el.scrollWidth <= el.clientWidth) {
+          truncated = candidate;
+          start = mid + 1;
+        } else {
+          end = mid;
+        }
+      }
+
+      if (displayUrl !== truncated) {
+        setDisplayUrl(truncated);
+      }
+    };
+
+    updateDisplay();
+    window.addEventListener('resize', updateDisplay);
+    return () => {
+      window.removeEventListener('resize', updateDisplay);
+    };
+  }, [url, displayUrl]);
+
   return (
     <Box
       sx={{
@@ -14,16 +59,17 @@ const UrlDisplayBox: React.FC<UrlDisplayBoxProps> = ({ url }) => {
         alignItems: 'center',
         minWidth: 0,
         flexBasis: '50%',
+        maxWidth: '50vw',
         justifyContent: 'flex-end',
       }}
     >
       <Typography
         variant="h6"
         sx={{
-          fontSize: { xs: '0.85rem', sm: '0.9rem' },
+          fontSize: { xs: '0.95rem', sm: '1rem' },
           color: 'white',
           overflow: 'hidden',
-          textOverflow: 'ellipsis',
+          textOverflow: 'clip',
           whiteSpace: 'nowrap',
           cursor: 'pointer',
           fontWeight: 'bold',
@@ -36,8 +82,9 @@ const UrlDisplayBox: React.FC<UrlDisplayBoxProps> = ({ url }) => {
         target="_blank"
         rel="noopener noreferrer"
         underline="hover"
+        title={url}
       >
-        {url}
+        {displayUrl}
       </Typography>
     </Box>
   );


### PR DESCRIPTION
## Summary
- stop automatic ellipsis so custom `[…]` shows

## Testing
- `npm run check`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685ca99aeb98832bb7b0c2a56c8fc03e