### PR TITLE
Fix progress bar styling

### DIFF
--- a/client/src/components/dashboard/AccessibilitySnapshot.tsx
+++ b/client/src/components/dashboard/AccessibilitySnapshot.tsx
@@ -70,10 +70,16 @@ const AccessibilitySnapshot = () => {
               {Math.max(0, score)}%
             </Typography>
             <Box flexGrow={1}>
-              <LinearProgress 
-                variant="determinate" 
-                value={Math.max(0, score)} 
-                sx={{ height: 8, borderRadius: 4 }}
+              <LinearProgress
+                variant="determinate"
+                value={Math.max(0, score)}
+                sx={{
+                  height: 8,
+                  borderRadius: 4,
+                  '& .MuiLinearProgress-bar': {
+                    borderRadius: 4,
+                  },
+                }}
               />
             </Box>
           </Box>

--- a/client/src/components/dashboard/ContentAnalysisTab.tsx
+++ b/client/src/components/dashboard/ContentAnalysisTab.tsx
@@ -229,14 +229,17 @@ const ContentAnalysisTab = ({ data, loading, error }: ContentAnalysisTabProps) =
                 enterDelay={300}
                 enterTouchDelay={300}
               >
-                <LinearProgress 
-                  variant="determinate" 
-                  value={readabilityScore} 
-                  sx={{ 
-                    height: 8, 
-                    borderRadius: 4, 
-                    cursor: 'help'
-                  }} 
+                <LinearProgress
+                  variant="determinate"
+                  value={readabilityScore}
+                  sx={{
+                    height: 8,
+                    borderRadius: 4,
+                    cursor: 'help',
+                    '& .MuiLinearProgress-bar': {
+                      borderRadius: 4,
+                    },
+                  }}
                 />
               </Tooltip>
               <Typography variant="body2" color="text.secondary">
@@ -260,14 +263,17 @@ const ContentAnalysisTab = ({ data, loading, error }: ContentAnalysisTabProps) =
                 enterDelay={300}
                 enterTouchDelay={300}
               >
-                <LinearProgress 
-                  variant="determinate" 
-                  value={textAccessibilityScore} 
-                  sx={{ 
-                    height: 8, 
-                    borderRadius: 4, 
-                    cursor: 'help'
-                  }} 
+                <LinearProgress
+                  variant="determinate"
+                  value={textAccessibilityScore}
+                  sx={{
+                    height: 8,
+                    borderRadius: 4,
+                    cursor: 'help',
+                    '& .MuiLinearProgress-bar': {
+                      borderRadius: 4,
+                    },
+                  }}
                 />
               </Tooltip>
               <Typography variant="body2" color="text.secondary">
@@ -293,14 +299,17 @@ const ContentAnalysisTab = ({ data, loading, error }: ContentAnalysisTabProps) =
                 enterDelay={300}
                 enterTouchDelay={300}
               >
-                <LinearProgress 
-                  variant="determinate" 
-                  value={totalImages > 0 ? (estimatedPhotos / totalImages) * 100 : 0} 
-                  sx={{ 
-                    height: 8, 
-                    borderRadius: 4, 
-                    cursor: 'help'
-                  }} 
+                <LinearProgress
+                  variant="determinate"
+                  value={totalImages > 0 ? (estimatedPhotos / totalImages) * 100 : 0}
+                  sx={{
+                    height: 8,
+                    borderRadius: 4,
+                    cursor: 'help',
+                    '& .MuiLinearProgress-bar': {
+                      borderRadius: 4,
+                    },
+                  }}
                 />
               </Tooltip>
               <Typography variant="body2" color="text.secondary">

--- a/client/src/components/dashboard/MobileResponsiveness.tsx
+++ b/client/src/components/dashboard/MobileResponsiveness.tsx
@@ -59,10 +59,16 @@ const MobileResponsiveness = () => {
               {score}%
             </Typography>
             <Box flexGrow={1}>
-              <LinearProgress 
-                variant="determinate" 
-                value={score} 
-                sx={{ height: 8, borderRadius: 4 }}
+              <LinearProgress
+                variant="determinate"
+                value={score}
+                sx={{
+                  height: 8,
+                  borderRadius: 4,
+                  '& .MuiLinearProgress-bar': {
+                    borderRadius: 4,
+                  },
+                }}
               />
             </Box>
           </Box>

--- a/client/src/components/dashboard/PerformanceTab.tsx
+++ b/client/src/components/dashboard/PerformanceTab.tsx
@@ -336,10 +336,16 @@ function MobileResponsivenessSection() {
               {score}%
             </Typography>
           </Box>
-          <LinearProgress 
-            variant="determinate" 
-            value={score} 
-            sx={{ height: 8, borderRadius: 4 }}
+          <LinearProgress
+            variant="determinate"
+            value={score}
+            sx={{
+              height: 8,
+              borderRadius: 4,
+              '& .MuiLinearProgress-bar': {
+                borderRadius: 4,
+              },
+            }}
           />
         </Box>
 


### PR DESCRIPTION
## Summary
- improve the `LinearProgress` styles for snapshot charts
- ensure text content quality bars have rounded fill styles
- round the progress bar in mobile performance widget

## Testing
- `npm test` *(fails: Cannot find type definition file for 'node')*

------
https://chatgpt.com/codex/tasks/task_e_685e0be8d6e8832b983d226e08aaf368