### PR TITLE
Fix Accessibility Score progress bar styling

### DIFF
--- a/client/src/components/dashboard/ui-analysis/ContrastWarningsCard.tsx
+++ b/client/src/components/dashboard/ui-analysis/ContrastWarningsCard.tsx
@@ -87,7 +87,7 @@ const ContrastWarningsCard: React.FC<ContrastWarningsCardProps> = ({ issues, dat
           <Typography variant="subtitle1" sx={{ fontWeight: 'bold' }}>
             Accessibility Score
           </Typography>
-          <Typography variant="h6" sx={{ fontWeight: 'bold', color: score >= 80 ? 'success.main' : score >= 60 ? 'warning.main' : 'error.main' }}>
+          <Typography variant="h6" sx={{ fontWeight: 'bold' }}>
             {score}%
           </Typography>
         </Box>
@@ -97,9 +97,7 @@ const ContrastWarningsCard: React.FC<ContrastWarningsCardProps> = ({ issues, dat
           sx={{
             height: 8,
             borderRadius: 4,
-            backgroundColor: 'grey.200',
             '& .MuiLinearProgress-bar': {
-              backgroundColor: score >= 80 ? 'success.main' : score >= 60 ? 'warning.main' : 'error.main',
               borderRadius: 4,
             },
           }}


### PR DESCRIPTION
## Summary
- make the Accessibility Score progress bar match the styling used for Speed Index

## Testing
- `npm run test` *(fails: Cannot find type definition file for 'node')*

------
https://chatgpt.com/codex/tasks/task_e_685e1066da4c832baa0ff732ae61d886