### PR TITLE
Update mobile tab labels and shorten buttons

### DIFF
--- a/client/src/components/DashboardContent.tsx
+++ b/client/src/components/DashboardContent.tsx
@@ -91,10 +91,10 @@ const DashboardContent = () => {
               >
                 <TabsList className="grid w-full grid-cols-3 md:grid-cols-7 gap-1 h-auto">
                   <TabsTrigger value="overview" className="col-span-3 md:col-span-1 text-xs sm:text-sm" data-tab-id="overview">Overview</TabsTrigger>
-                  <TabsTrigger value="ui" className="text-xs sm:text-sm" data-tab-id="ui">User Interface</TabsTrigger>
+                  <TabsTrigger value="ui" className="text-xs sm:text-sm" data-tab-id="ui">UI</TabsTrigger>
                   <TabsTrigger value="content" className="text-xs sm:text-sm" data-tab-id="content">Content</TabsTrigger>
-                  <TabsTrigger value="performance" className="text-xs sm:text-sm" data-tab-id="performance">Performance & Security</TabsTrigger>
-                  <TabsTrigger value="seo" className="text-xs sm:text-sm" data-tab-id="seo">SEO Analysis</TabsTrigger>
+                  <TabsTrigger value="performance" className="text-xs sm:text-sm" data-tab-id="performance">Performance</TabsTrigger>
+                  <TabsTrigger value="seo" className="text-xs sm:text-sm" data-tab-id="seo">SEO</TabsTrigger>
                   <TabsTrigger value="tech" className="text-xs sm:text-sm" data-tab-id="tech">Tech</TabsTrigger>
                   <TabsTrigger value="compliance" className="text-xs sm:text-sm" data-tab-id="compliance">Compliance</TabsTrigger>
                 </TabsList>

--- a/client/src/components/ui/tabs.tsx
+++ b/client/src/components/ui/tabs.tsx
@@ -27,7 +27,7 @@ const TabsTrigger = React.forwardRef<
   <TabsPrimitive.Trigger
     ref={ref}
     className={cn(
-      "inline-flex items-center justify-center rounded-sm px-3 py-1.5 text-sm font-medium ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:bg-background data-[state=active]:text-foreground data-[state=active]:shadow-sm",
+      "inline-flex items-center justify-center rounded-sm px-3 py-1 text-sm font-medium ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:bg-background data-[state=active]:text-foreground data-[state=active]:shadow-sm",
       className
     )}
     {...props}


### PR DESCRIPTION
## Summary
- shorten tab labels for mobile navigation
- reduce tab button height

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685e2f568004832b960dd8f948cd8079