### PR TITLE
Match Core Web Vitals chart style to Content Structure

### DIFF
--- a/client/src/components/dashboard/PerformanceTab.tsx
+++ b/client/src/components/dashboard/PerformanceTab.tsx
@@ -12,6 +12,7 @@ import {
 } from '@mui/material';
 import { ChartContainer, ChartTooltip, ChartTooltipContent } from '../ui/chart';
 import { BarChart as RechartsBarChart, Bar, XAxis, YAxis } from 'recharts';
+import { useTheme } from '@mui/material/styles';
 import { Shield, Smartphone, Zap, Activity, ShieldCheck, Gauge, BarChart } from 'lucide-react';
 import type { AnalysisResponse } from '@/types/analysis';
 import { useAnalysisContext } from '../../contexts/AnalysisContext';
@@ -117,9 +118,10 @@ function MetricsSection({ performanceScore, mobileScore, securityScore }: {
 }
 
 function CoreWebVitalsSection({ performance }: { performance: AnalysisResponse["data"]["performance"] }) {
+  const theme = useTheme();
   const chartConfig = {
-    value: { label: 'Your Site', color: '#2196F3' },
-    benchmark: { label: 'Industry Average', color: '#E0E0E0' }
+    value: { label: 'Your Site', color: '#FF6B35' },
+    benchmark: { label: 'Benchmark', color: theme.palette.grey[300] }
   };
   return (
     <Card sx={{ borderRadius: 2, height: '400px', width: '100%', maxWidth: '100%', minWidth: 0 }}>
@@ -139,16 +141,13 @@ function CoreWebVitalsSection({ performance }: { performance: AnalysisResponse["
             <ChartContainer config={chartConfig} className="h-80">
               <RechartsBarChart
                 data={performance.coreWebVitals}
-                margin={{ top: 20, right: 30, left: 5, bottom: 5 }}
-                barCategoryGap={20}
-                barGap={8}
-                maxBarSize={30}
+                margin={{ top: 20, right: 30, left: 20, bottom: 5 }}
               >
-                <XAxis dataKey="name" tick={{ fontSize: 12 }} />
+                <XAxis dataKey="name" tick={{ fontSize: 10 }} />
                 <YAxis />
-                <ChartTooltip cursor={false} content={<ChartTooltipContent />} />
-                <Bar dataKey="value" fill="var(--color-value)" maxBarSize={40} />
-                <Bar dataKey="benchmark" fill="var(--color-benchmark)" maxBarSize={40} />
+                <ChartTooltip content={<ChartTooltipContent />} />
+                <Bar dataKey="value" fill="#FF6B35" />
+                <Bar dataKey="benchmark" fill={theme.palette.grey[300]} />
               </RechartsBarChart>
             </ChartContainer>
           </Box>


### PR DESCRIPTION
## Summary
- update Core Web Vitals bar chart styling to match Content Structure Analysis
- use MUI theme grey tone and consistent orange accent

## Testing
- `npx tsc -p tsconfig.test.json --outDir dist`
- `bash tests/run-tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_685e0ffc38a0832bb076feab47d9ddd5