### PR TITLE
Align Core Web Vitals chart formatting

### DIFF
--- a/client/src/components/dashboard/ContentAnalysisTab.tsx
+++ b/client/src/components/dashboard/ContentAnalysisTab.tsx
@@ -173,8 +173,8 @@ const ContentAnalysisTab = ({ data, loading, error }: ContentAnalysisTabProps) =
                   Content Structure Analysis
                 </Typography>
               </Box>
-            <ChartContainer config={chartConfig} className="h-80">
-              <BarChart data={contentStructureData} margin={{ top: 20, right: 30, left: 20, bottom: 5 }}>
+            <ChartContainer config={chartConfig} className="h-80 w-full">
+              <BarChart data={contentStructureData} margin={{ top: 20, right: 30, left: 10, bottom: 5 }}>
                 <XAxis dataKey="metric" tick={{ fontSize: 10 }} />
                 <YAxis domain={[0, 100]} />
                 <ChartTooltip cursor={false} content={<ChartTooltipContent />} />

--- a/client/src/components/dashboard/PerformanceTab.tsx
+++ b/client/src/components/dashboard/PerformanceTab.tsx
@@ -132,27 +132,19 @@ function CoreWebVitalsSection({ performance }: { performance: AnalysisResponse["
             Core Web Vitals
           </Typography>
         </Box>
-        <Box sx={{ overflowX: 'auto', width: '100%', pb: 1 }}>
-          <Box sx={{
-            minWidth: { xs: 320, sm: 400 },
-            width: { xs: 320, sm: 400, md: '100%' },
-            maxWidth: 'none'
-          }}>
-            <ChartContainer config={chartConfig} className="h-80">
-              <RechartsBarChart
-                data={performance.coreWebVitals}
-                margin={{ top: 20, right: 30, left: 20, bottom: 5 }}
-              >
-                <XAxis dataKey="name" tick={{ fontSize: 10 }} />
-                <YAxis />
+        <ChartContainer config={chartConfig} className="h-80 w-full">
+          <RechartsBarChart
+            data={performance.coreWebVitals}
+            margin={{ top: 20, right: 30, left: 10, bottom: 5 }}
+          >
+            <XAxis dataKey="name" tick={{ fontSize: 10 }} />
+            <YAxis domain={[0, 100]} />
 
-                <ChartTooltip cursor={false} content={<ChartTooltipContent />} />
-                <Bar dataKey="value" fill="#FF6B35" />
-                <Bar dataKey="benchmark" fill={theme.palette.grey[300]} />
-              </RechartsBarChart>
-            </ChartContainer>
-          </Box>
-        </Box>
+            <ChartTooltip cursor={false} content={<ChartTooltipContent />} />
+            <Bar dataKey="value" fill="#FF6B35" />
+            <Bar dataKey="benchmark" fill={theme.palette.grey[300]} />
+          </RechartsBarChart>
+        </ChartContainer>
       </CardContent>
     </Card>
   );


### PR DESCRIPTION
## Summary
- make Core Web Vitals chart use the same layout as Content Structure Analysis
- widen both charts and reduce left padding

## Testing
- `npm test` *(fails: Cannot find type definition file for 'node')*

------
https://chatgpt.com/codex/tasks/task_e_685fefd61bdc832b864edb2b8d1097d2