### PR TITLE
Restore rounded LinearProgress bars

### DIFF
--- a/client/src/theme/theme.ts
+++ b/client/src/theme/theme.ts
@@ -116,6 +116,18 @@ export const createAppTheme = (darkMode: boolean) => createTheme({
         },
       },
     },
+    MuiLinearProgress: {
+      styleOverrides: {
+        root: {
+          borderRadius: 4,
+          overflow: 'hidden',
+          '&.noClip': { overflow: 'visible' },
+        },
+        bar: {
+          borderRadius: 4,
+        },
+      },
+    },
   },
 });
 


### PR DESCRIPTION
## Summary
- globally enforce rounded caps for `MuiLinearProgress`

## Testing
- `npm test`
- `npm run dev:ui` *(fails: server runs but can't verify UI in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_6861541df188832bb78e3ca063663e7b