### PR TITLE
Fix accessibility score bar style

### DIFF
--- a/client/src/components/dashboard/ui-analysis/ContrastWarningsCard.tsx
+++ b/client/src/components/dashboard/ui-analysis/ContrastWarningsCard.tsx
@@ -97,11 +97,6 @@ const ContrastWarningsCard: React.FC<ContrastWarningsCardProps> = ({ issues, dat
           sx={{
             height: 8,
             borderRadius: 4,
-            backgroundColor: 'grey.200',
-            '& .MuiLinearProgress-bar': {
-              backgroundColor: score >= 80 ? 'success.main' : score >= 60 ? 'warning.main' : 'error.main',
-              borderRadius: 4,
-            },
           }}
         />
       </Box>


### PR DESCRIPTION
## Summary
- update progress bar in ContrastWarningsCard to use standard styling

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68615769a01c832b91a2ef0b3b5c46ac