### PR TITLE
Reduce header gradient height

### DIFF
--- a/client/src/components/dashboard/OverviewTab.tsx
+++ b/client/src/components/dashboard/OverviewTab.tsx
@@ -84,7 +84,8 @@ const OverviewTab: React.FC<OverviewTabProps> = ({ data, loading, error }) => {
           mb: 3,
           mx: -3, // Extend beyond card padding
           px: 3, // Add padding back for content
-          py: 2,
+          // Slightly reduced padding to make the gradient header shorter
+          py: 1.5,
         }}
       >
         {/* Orange gradient background - stops before edge, larger transparent section */}


### PR DESCRIPTION
## Summary
- tweak the `OverviewTab` header padding so the orange gradient isn't so tall

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68615f460ba8832baf1d502c5f3820c7