### PR TITLE
Fix overview fallback placeholders

### DIFF
--- a/client/src/components/dashboard/overview/KeyFindingsGrid.tsx
+++ b/client/src/components/dashboard/overview/KeyFindingsGrid.tsx
@@ -21,24 +21,24 @@ const KeyFindingsGrid: React.FC<KeyFindingsGridProps> = ({ overview, theme }) =>
       <Box sx={{ display: 'flex', justifyContent: 'space-between', mb: 0.5 }}>
         <Typography variant="body2">Overall Score</Typography>
         <Tooltip 
-          title={getScoreTooltip(overview.overallScore ?? 0, 'overall performance')}
+          title={getScoreTooltip(overview.overallScore ?? "!", 'overall performance')}
           enterDelay={300}
           enterTouchDelay={300}
         >
-          <Typography variant="body2" sx={{ fontWeight: 'bold', color: scoreColor(overview.overallScore ?? 0), cursor: 'help' }}>
-            {overview.overallScore ?? 0}/100
+          <Typography variant="body2" sx={{ fontWeight: 'bold', color: scoreColor(overview.overallScore ?? "!"), cursor: 'help' }}>
+            {overview.overallScore ?? "!"}/100
           </Typography>
         </Tooltip>
       </Box>
       <Box sx={{ display: 'flex', justifyContent: 'space-between', mb: 0.5 }}>
         <Typography variant="body2">SEO Score</Typography>
         <Tooltip 
-          title={getScoreTooltip(overview.seoScore ?? 0, 'SEO optimization')}
+          title={getScoreTooltip(overview.seoScore ?? "!", 'SEO optimization')}
           enterDelay={300}
           enterTouchDelay={300}
         >
-          <Typography variant="body2" sx={{ fontWeight: 'bold', color: scoreColor(overview.seoScore ?? 0), cursor: 'help' }}>
-            {overview.seoScore ?? 0}/100
+          <Typography variant="body2" sx={{ fontWeight: 'bold', color: scoreColor(overview.seoScore ?? "!"), cursor: 'help' }}>
+            {overview.seoScore ?? "!"}/100
           </Typography>
         </Tooltip>
       </Box>
@@ -50,14 +50,14 @@ const KeyFindingsGrid: React.FC<KeyFindingsGridProps> = ({ overview, theme }) =>
           enterTouchDelay={300}
         >
           <Typography variant="body2" sx={{ fontWeight: 'bold', color: '#FF9800', cursor: 'help' }}>
-            {overview.pageLoadTime ?? 'Unknown'}
+            {overview.pageLoadTime ?? "!"}
           </Typography>
         </Tooltip>
       </Box>
       <Box sx={{ display: 'flex', justifyContent: 'space-between', mb: 0.5 }}>
         <Typography variant="body2">User Experience</Typography>
         <Tooltip 
-          title={getScoreTooltip(overview.userExperienceScore ?? 0, 'user experience')}
+          title={getScoreTooltip(overview.userExperienceScore ?? "!", 'user experience')}
           enterDelay={300}
           enterTouchDelay={300}
         >
@@ -65,11 +65,11 @@ const KeyFindingsGrid: React.FC<KeyFindingsGridProps> = ({ overview, theme }) =>
             variant="body2"
             sx={{
               fontWeight: 'bold',
-              color: (overview.userExperienceScore ?? 0) >= 80 ? '#4CAF50' : '#2196F3',
+              color: (overview.userExperienceScore ?? "!") >= 80 ? '#4CAF50' : '#2196F3',
               cursor: 'help'
             }}
           >
-            {overview.userExperienceScore ?? 0}/100
+            {overview.userExperienceScore ?? "!"}/100
           </Typography>
         </Tooltip>
       </Box>

--- a/client/src/components/dashboard/overview/MetricInfoPopover.tsx
+++ b/client/src/components/dashboard/overview/MetricInfoPopover.tsx
@@ -18,7 +18,7 @@ const MetricInfoPopover: React.FC<MetricInfoPopoverProps> = ({ anchorEl, infoTex
   >
     <Box sx={{ p: 2, maxWidth: 250 }}>
       <Typography variant="body2">
-        {infoText || '— No data available —'}
+        {infoText || "!"}
       </Typography>
     </Box>
   </Popover>

--- a/client/src/components/dashboard/overview/metricDefinitions.ts
+++ b/client/src/components/dashboard/overview/metricDefinitions.ts
@@ -11,22 +11,22 @@ export const getMetricDefinitions = (overview: AnalysisResponse['data']['overvie
   return [
   {
     titleLines: ['Overall', 'Score'],
-    value: `${overview.overallScore ?? 0}/100`,
+    value: `${overview.overallScore ?? "!"}/100`,
     icon: Star,
-    color: useScoreColor(theme)(overview.overallScore ?? 0),
+    color: useScoreColor(theme)(overview.overallScore ?? "!"),
     description: getScoreDescription(
-      overview.overallScore ?? 0,
+      overview.overallScore ?? "!",
       'Excellent performance overall',
       'Good, could be improved',
       'Needs improvement',
     ),
     info:
       'Overall score weights performance (40%), SEO (40%) and user experience (20%) based on the collected metrics.',
-    tooltip: getScoreTooltip(overview.overallScore ?? 0, 'overall performance'),
+      tooltip: getScoreTooltip(overview.overallScore ?? "!", 'overall performance'),
   },
   {
     titleLines: ['Page Load', 'Time'],
-    value: overview.pageLoadTime ? `${overview.pageLoadTime}s` : 'Loading...',
+    value: overview.pageLoadTime ? `${overview.pageLoadTime}s` : "!",
     icon: Clock,
     color: theme.palette.warning.main,
     description: 'Page loading performance',
@@ -35,19 +35,19 @@ export const getMetricDefinitions = (overview: AnalysisResponse['data']['overvie
   },
   {
     titleLines: ['SEO', 'Score'],
-    value: `${overview.seoScore ?? 0}/100`,
+    value: `${overview.seoScore ?? "!"}/100`,
     icon: TrendingUp,
-    color: useScoreColor(theme)(overview.seoScore ?? 0),
-    description: (overview.seoScore ?? 0) >= 80 ? 'Excellent SEO optimization' : 'SEO could be improved',
-    tooltip: getScoreTooltip(overview.seoScore ?? 0, 'SEO optimization'),
+    color: useScoreColor(theme)(overview.seoScore ?? "!"),
+    description: (overview.seoScore ?? "!") >= 80 ? 'Excellent SEO optimization' : 'SEO could be improved',
+    tooltip: getScoreTooltip(overview.seoScore ?? "!", 'SEO optimization'),
   },
   {
     titleLines: ['User', 'Experience'],
-    value: `${overview.userExperienceScore ?? 0}/100`,
+    value: `${overview.userExperienceScore ?? "!"}/100`,
     icon: Users,
-    color: (overview.userExperienceScore ?? 0) >= 80 ? theme.palette.success.main : theme.palette.primary.main,
-    description: (overview.userExperienceScore ?? 0) >= 80 ? 'Excellent user experience' : 'Good user experience',
-    tooltip: getScoreTooltip(overview.userExperienceScore ?? 0, 'user experience'),
+    color: (overview.userExperienceScore ?? "!") >= 80 ? theme.palette.success.main : theme.palette.primary.main,
+    description: (overview.userExperienceScore ?? "!") >= 80 ? 'Excellent user experience' : 'Good user experience',
+    tooltip: getScoreTooltip(overview.userExperienceScore ?? "!", 'user experience'),
   },
 ];
 };


### PR DESCRIPTION
## Summary
- update overview metric definitions to show `!` when data is missing
- render `!` for placeholder values in KeyFindingsGrid
- show `!` in MetricInfoPopover when there is no info text

## Testing
- `npm test` *(fails: Cannot find type definition file for 'node')*

------
https://chatgpt.com/codex/tasks/task_e_686b6183397c832ba4242c924259a81f