### PR TITLE
Add migrate:supabase script

### DIFF
--- a/package.jsonc
+++ b/package.jsonc
@@ -13,6 +13,7 @@
     "check": "tsc",
     "db:push": "drizzle-kit push",
     "deps:docs": "npx dep-table --out docs/DEPENDENCIES.md",
+    "migrate:supabase": "npx drizzle-kit push:pg --schema \"postgres\".\"public\"",
     "test": "bash tests/run-tests.sh"
   },
   "dependencies": {


### PR DESCRIPTION
## Summary
- add `migrate:supabase` script to automate pushing Postgres schema to Supabase via Drizzle

## Testing
- `bash tests/run-tests.sh`


------
https://chatgpt.com/codex/tasks/task_e_687ba2bc2188832babb3afe162f850e0