### PR TITLE
Remove API dependent navigation in UI

### DIFF
--- a/client/src/components/HeroSection.tsx
+++ b/client/src/components/HeroSection.tsx
@@ -63,26 +63,21 @@ const MASK_IMAGE = `linear-gradient(
  * @param loading Prevents new analysis while running
  * @param error Analysis error, triggers UX delay/route
  */
-const handleRecentSearch = async ({
+const handleRecentSearch = ({
   searchUrl,
   analyzeWebsite,
   navigate,
-  error,
   loading,
 }: {
-  searchUrl: string,
-  analyzeWebsite: (url: string) => Promise<any>,
-  navigate: (path: string) => void,
-  error: any,
-  loading: boolean,
+  searchUrl: string;
+  analyzeWebsite: (url: string) => Promise<any>;
+  navigate: (path: string) => void;
+  loading: boolean;
 }) => {
   if (loading) return;
   const fullUrl = `https://${searchUrl}`;
-  const result = await analyzeWebsite(fullUrl);
-  if (result && !error) {
-    // Smooth navigation to dashboard after successful analysis
-    setTimeout(() => navigate('/dashboard'), 500);
-  }
+  analyzeWebsite(fullUrl);
+  navigate('/dashboard');
 };
 
 /**
@@ -92,12 +87,8 @@ const handleRecentSearch = async ({
  * @param navigate React Router navigate function
  * @param error Analysis error
  */
-const handleAnalysisComplete = (
-  result: any, navigate: (path: string) => void, error: any
-) => {
-  if (result && !error) {
-    setTimeout(() => navigate('/dashboard'), 500);
-  }
+const handleAnalysisComplete = (navigate: (path: string) => void) => {
+  navigate('/dashboard');
 };
 
 const HeroSection = () => {
@@ -271,7 +262,7 @@ const HeroSection = () => {
           {/* Input & popular sites shortcuts */}
           <Box sx={{ width: '100%', display: 'flex', justifyContent: 'center', flexDirection: 'column', alignItems: 'center', zIndex: 3, position: 'relative' }}>
             <URLInputForm
-              onAnalysisComplete={result => handleAnalysisComplete(result, navigate, error)}
+              onAnalysisComplete={() => handleAnalysisComplete(navigate)}
             />
             <Box 
               component={motion.div}

--- a/client/src/components/URLInputForm.tsx
+++ b/client/src/components/URLInputForm.tsx
@@ -39,17 +39,13 @@ const URLInputForm: React.FC<URLInputFormProps> = ({ onAnalysisComplete }) => {
     if (!url.trim() || localLoading || loading) return;
 
     setLocalLoading(true);
-    
+
     try {
-      // Start the analysis and wait for it to be properly initiated
-      const result = await analyzeWebsite(url.trim());
-      
-      // Navigate to dashboard after analysis is properly started
+      analyzeWebsite(url.trim());
       navigate('/dashboard');
-      
-      // Call completion callback if provided
+
       if (onAnalysisComplete) {
-        onAnalysisComplete({ url: url.trim(), result });
+        onAnalysisComplete({ url: url.trim() });
       }
     } catch (error) {
       console.error('Analysis start failed:', error);

--- a/client/src/pages/AnalyzePage.tsx
+++ b/client/src/pages/AnalyzePage.tsx
@@ -53,33 +53,26 @@ const handleRecentSearch = async ({
   searchUrl,
   analyzeWebsite,
   navigate,
-  error,
   loading,
 }: {
   searchUrl: string,
   analyzeWebsite: (url: string) => Promise<any>,
   navigate: (path: string) => void,
-  error: any,
   loading: boolean,
 }) => {
   if (loading) return;
   const fullUrl = `https://${searchUrl}`;
-  const result = await analyzeWebsite(fullUrl);
-  if (result && !error) {
-    // Smooth navigation to dashboard after successful analysis
-    setTimeout(() => navigate('/dashboard'), 500);
-  }
+  analyzeWebsite(fullUrl);
+  navigate('/dashboard');
 };
 
 /**
  * Handles successful analysis completion from the URL input form.
  */
 const handleAnalysisComplete = (
-  result: any, navigate: (path: string) => void, error: any
+  navigate: (path: string) => void
 ) => {
-  if (result && !error) {
-    setTimeout(() => navigate('/dashboard'), 500);
-  }
+  navigate('/dashboard');
 };
 
 const AnalyzePage = ({ darkMode, toggleDarkMode }: AnalyzePageProps) => {
@@ -258,7 +251,7 @@ const AnalyzePage = ({ darkMode, toggleDarkMode }: AnalyzePageProps) => {
             {/* Input & popular sites shortcuts */}
             <Box sx={{ width: '100%', display: 'flex', justifyContent: 'center', flexDirection: 'column', alignItems: 'center', zIndex: 3, position: 'relative' }}>
               <URLInputForm
-                onAnalysisComplete={result => handleAnalysisComplete(result, navigate, error)}
+                onAnalysisComplete={() => handleAnalysisComplete(navigate)}
               />
               <motion.div {...motionProps.formSection}>
                 <Typography


### PR DESCRIPTION
## Summary
- clean up HeroSection and AnalyzePage callbacks
- remove result-based logic in URLInputForm

## Testing
- `npm run typecheck` *(fails: Could not read package.json)*
- `npm run dev` *(fails: Could not read package.json)*
- `rg -n "(/api/|results\.sort\(|setQueryData|panelState)" client/src || echo "Clean ✅"`

------
https://chatgpt.com/codex/tasks/task_e_687c469d9eb0832bbcbaa4042af7158d