### PR TITLE
Add Supabase schema docs and references

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,14 @@ npm run dev
 
 *Need to know more? See [`docs/TECH_STACK.md`](docs/TECH_STACK.md) for narratives and [`docs/DEPENDENCIES.md`](docs/DEPENDENCIES.md) for **every** package with a one‑liner.*
 
+## Database Schema
+We use three Supabase tables to manage requests, progress, and cached results:
+- **scans**  – Master record of scan requests (URL, user ID, timestamps).
+- **scan_status**  – Real-time status & progress of each scan.
+- **analysis_cache**  – Cached audit results keyed by URL hash.
+
+See [`docs/SUPABASE_SCHEMA.md`](docs/SUPABASE_SCHEMA.md) for full column definitions and policies.
+
 ### Advanced Analysis Capabilities
 
 **SEO Analysis** - Blended scoring system combining:

--- a/docs/DEPENDENCIES.md
+++ b/docs/DEPENDENCIES.md
@@ -71,6 +71,7 @@
 | dep-table | ^1.0.0 | Dependency table generator | DevDependency |
 | drizzle-kit | ^0.30.6 | Generate SQL migrations | DevDependency |
 | drizzle-orm | ^0.39.3 | Type-safe ORM | Dependency |
+**Database tables required:** `scans`, `scan_status`, `analysis_cache` (Supabase schema defined in docs/SUPABASE_SCHEMA.md)
 | drizzle-zod | ^0.7.0 | Drizzle schema validation | Dependency |
 | embla-carousel-react | ^8.6.0 | Carousel component | Dependency |
 | esbuild | ^0.25.0 | Fast TS/JS bundler | DevDependency |

--- a/docs/SUPABASE_SCHEMA.md
+++ b/docs/SUPABASE_SCHEMA.md
@@ -1,0 +1,27 @@
+# Supabase Schema Reference
+
+## scans
+• **id** (uuid PK) – auto‑generated via `uuid_generate_v4()`  
+• **user_id** (uuid) – FK → `auth.users.id`, nullable for anonymous  
+• **url** (text) – unique canonical URL  
+• **created_at** (timestamptz) – default `now()`  
+• **last_run_at** (timestamptz) – timestamp of last audit  
+• **active** (boolean) – default `true` (soft‑delete)
+
+## scan_status
+• **scan_id** (uuid PK) – FK → `scans.id`, cascade on delete  
+• **status** (text) – one of `queued`, `running`, `complete`, `failed`  
+• **progress** (smallint) – percent complete (0–100)  
+• **started_at**, **finished_at** (timestamptz)  
+• **error** (text) – error message if failed
+
+## analysis_cache
+• **id** (uuid PK) – auto‑generated  
+• **url_hash** (text) – unique SHA‑256 or similar hash of URL  
+• **original_url** (text) – the raw URL  
+• **created_at**, **expires_at** (timestamptz)  
+• **audit_json** (jsonb) – stored Lighthouse/Playwright result
+
+**Realtime & Policies:**
+- Enable Realtime broadcasts on `scan_status` for live updates.  
+- Set RLS: users can `SELECT`/`INSERT`/`UPDATE` their own `scans` and `scan_status`; `analysis_cache` is public read-only.

--- a/docs/TECH_STACK.md
+++ b/docs/TECH_STACK.md
@@ -90,6 +90,12 @@ The application features a sophisticated multi-tier analysis system powered by i
 * **Drizzle Zod** - Package: `drizzle-zod`
   * Runtime validation with TypeScript integration
 
+## Database Schema
+We persist and manage scans using Supabase tables. See [`docs/SUPABASE_SCHEMA.md`](docs/SUPABASE_SCHEMA.md) for table details:
+- **scans**: stores all scan requests.
+- **scan_status**: tracks queue/running/completion per scan.
+- **analysis_cache**: stores JSON audit blobs for reuse.
+
 ### Utility & Helper Libraries
 
 * **clsx** / **class-variance-authority** - Build conditional Tailwind class strings


### PR DESCRIPTION
## Summary
- document Supabase tables in README and tech stack docs
- add SUPABASE_SCHEMA.md with table definitions
- cross-reference new doc from dependencies list

## Testing
- `node tests/analysisDefaults.test.js` *(fails: Cannot find module '/workspace/site-deconstructor/dist/lib/analysisDefaults.js')*

------
https://chatgpt.com/codex/tasks/task_e_687c7e0cdbf0832b83be106be12ca44e