### PR TITLE
Align analysis_cache fields across project

### DIFF
--- a/replit.md
+++ b/replit.md
@@ -369,17 +369,11 @@ A comprehensive website analysis tool that provides insights into performance, S
 2. Run the following SQL to create the analysis cache table:
 ```sql
 CREATE TABLE IF NOT EXISTS analysis_cache (
-  id UUID DEFAULT gen_random_uuid() PRIMARY KEY,
-  url_hash VARCHAR(64) UNIQUE NOT NULL,
-  url TEXT NOT NULL,
-  analysis_data JSONB NOT NULL,
-  created_at TIMESTAMPTZ DEFAULT NOW(),
-  updated_at TIMESTAMPTZ DEFAULT NOW()
+  id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+  url_hash TEXT NOT NULL UNIQUE,
+  original_url TEXT NOT NULL,
+  created_at timestamptz DEFAULT now(),
+  expires_at timestamptz,
+  audit_json JSONB NOT NULL
 );
-
-CREATE INDEX IF NOT EXISTS idx_analysis_cache_url_hash ON analysis_cache(url_hash);
-CREATE INDEX IF NOT EXISTS idx_analysis_cache_updated_at ON analysis_cache(updated_at);
-
-ALTER TABLE analysis_cache ENABLE ROW LEVEL SECURITY;
-CREATE POLICY "Allow service role access" ON analysis_cache FOR ALL USING (true);
 ```

--- a/server/lib/supabase.ts
+++ b/server/lib/supabase.ts
@@ -25,7 +25,7 @@ export interface AnalysisCacheRow {
   id: string;
   url_hash: string;
   original_url: string;
-  analysis_data: any;
+  audit_json: any;
   created_at: string;
   expires_at: string;
 }
@@ -73,13 +73,13 @@ export class SupabaseCacheService {
       const expirationTime = new Date();
       expirationTime.setHours(expirationTime.getHours() + this.CACHE_TTL_HOURS);
       
-      // Match the exact table structure from the screenshot: url_hash, original_url, analysis_data
+      // Match the exact table structure from the screenshot: url_hash, original_url, audit_json
       const { data, error } = await supabase
         .from(this.TABLE_NAME)
         .upsert({
           url_hash: urlHash,
           original_url: url,
-          analysis_data: analysisData,
+          audit_json: analysisData,
           expires_at: expirationTime.toISOString()
         }, {
           onConflict: 'url_hash'
@@ -143,14 +143,13 @@ ALTER TABLE analysis_cache DISABLE ROW LEVEL SECURITY;
         console.log(`📝 Please run this SQL in your Supabase SQL editor:`);
         console.log(`-- Create table matching your existing structure
 CREATE TABLE IF NOT EXISTS analysis_cache (
-  id UUID DEFAULT gen_random_uuid() PRIMARY KEY,
-  url_hash VARCHAR(64) UNIQUE NOT NULL,
-  original_url TEXT,
-  analysis_data JSONB NOT NULL,
-  created_at TIMESTAMPTZ DEFAULT NOW(),
-  expires_at TIMESTAMPTZ DEFAULT NOW()
+  id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+  url_hash TEXT NOT NULL UNIQUE,
+  original_url TEXT NOT NULL,
+  created_at timestamptz DEFAULT now(),
+  expires_at timestamptz,
+  audit_json JSONB NOT NULL
 );
-CREATE INDEX IF NOT EXISTS idx_analysis_cache_url_hash ON analysis_cache(url_hash);
 ALTER TABLE analysis_cache DISABLE ROW LEVEL SECURITY;`);
       }
       

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -1,4 +1,4 @@
-import { pgTable, text, serial, integer, boolean, timestamp, json } from "drizzle-orm/pg-core";
+import { pgTable, text, serial, uuid, timestamptz, jsonb } from "drizzle-orm/pg-core";
 import { createInsertSchema } from "drizzle-zod";
 import { z } from "zod";
 
@@ -9,12 +9,12 @@ export const users = pgTable("users", {
 });
 
 export const analysisCache = pgTable("analysis_cache", {
-  id: serial("id").primaryKey(),
+  id: uuid("id").primaryKey().defaultRandom(),
   urlHash: text("url_hash").notNull().unique(),
   originalUrl: text("original_url").notNull(),
-  analysisData: json("analysis_data").notNull(),
-  createdAt: timestamp("created_at").defaultNow().notNull(),
-  expiresAt: timestamp("expires_at").notNull(),
+  createdAt: timestamptz("created_at").notNull().defaultNow(),
+  expiresAt: timestamptz("expires_at"),
+  auditJson: jsonb("audit_json").notNull(),
 });
 
 export const insertUserSchema = createInsertSchema(users).pick({
@@ -25,7 +25,7 @@ export const insertUserSchema = createInsertSchema(users).pick({
 export const insertAnalysisCacheSchema = createInsertSchema(analysisCache).pick({
   urlHash: true,
   originalUrl: true,
-  analysisData: true,
+  auditJson: true,
   expiresAt: true,
 });
 


### PR DESCRIPTION
## Summary
- update Drizzle schema for `analysis_cache`
- refresh SQL setup instructions
- update SupabaseCacheService to use `audit_json`

## Testing
- `npm run typecheck` *(fails: ENOENT: no such file or directory, open '/workspace/site-deconstructor/package.json')*
- `npm run dev` *(fails: ENOENT: no such file or directory, open '/workspace/site-deconstructor/package.json')*

------
https://chatgpt.com/codex/tasks/task_e_687c7f1de3e8832b9dedaaf8361d0578