### PR TITLE
Remove dashboard loaders

### DIFF
--- a/client/src/components/dashboard/AccessibilitySnapshot.tsx
+++ b/client/src/components/dashboard/AccessibilitySnapshot.tsx
@@ -1,6 +1,6 @@
 
 import React from 'react';
-import { Box, Typography, Card, CardContent, LinearProgress, Alert, CircularProgress } from '@mui/material';
+import { Box, Typography, Card, CardContent, LinearProgress, Alert } from '@mui/material';
 import { useAnalysisContext } from '../../contexts/AnalysisContext';
 
 interface ViolationCardProps {
@@ -32,18 +32,7 @@ const ViolationCard: React.FC<ViolationCardProps> = ({ id, impact, description }
 );
 
 const AccessibilitySnapshot = () => {
-  const { data, loading, error } = useAnalysisContext();
-
-  if (loading) {
-    return (
-      <Box display="flex" justifyContent="center" alignItems="center" py={4}>
-        <CircularProgress />
-        <Typography variant="body1" sx={{ ml: 2 }}>
-          Analyzing accessibility...
-        </Typography>
-      </Box>
-    );
-  }
+  const { data, error } = useAnalysisContext();
 
   if (error) {
     return (

--- a/client/src/components/dashboard/ComplianceTab.tsx
+++ b/client/src/components/dashboard/ComplianceTab.tsx
@@ -5,7 +5,6 @@ import {
   Card,
   CardContent,
   Alert,
-  CircularProgress,
   Chip,
   useTheme,
   Tooltip,
@@ -194,14 +193,6 @@ const ComplianceTab: React.FC<ComplianceTabProps> = ({ data, loading, error }) =
               </Typography>
             </Box>
             
-            {loading ? (
-              <Box sx={{ display: 'flex', alignItems: 'center', py: 2 }}>
-                <CircularProgress size={20} sx={{ mr: 1 }} />
-                <Typography variant="body2" color="text.secondary">
-                  Analyzing security headers...
-                </Typography>
-              </Box>
-            ) : (
             <Box>
               {headerCategories.map((category, categoryIndex) => (
                 <Box key={categoryIndex} sx={{ mb: 2 }}>
@@ -385,14 +376,7 @@ const ComplianceTab: React.FC<ComplianceTabProps> = ({ data, loading, error }) =
                 Accessibility Violations
               </Typography>
             </Box>
-            {loading ? (
-              <Box sx={{ display: 'flex', alignItems: 'center', py: 2 }}>
-                <CircularProgress size={20} sx={{ mr: 1 }} />
-                <Typography variant="body2" color="text.secondary">
-                  Analyzing accessibility...
-                </Typography>
-              </Box>
-            ) : violations.length === 0 ? (
+            {violations.length === 0 ? (
               <Typography variant="body2">None</Typography>
             ) : (
               <Box component="ul" sx={{ pl: 2 }}>
@@ -422,14 +406,6 @@ const ComplianceTab: React.FC<ComplianceTabProps> = ({ data, loading, error }) =
               Other Checks
             </Typography>
           </Box>
-          {loading ? (
-            <Box sx={{ display: 'flex', alignItems: 'center', py: 2 }}>
-              <CircularProgress size={20} sx={{ mr: 1 }} />
-              <Typography variant="body2" color="text.secondary">
-                Analyzing compliance checks...
-              </Typography>
-            </Box>
-          ) : (
           <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 1, mb: 2 }}>
             <Tooltip
               title={social.hasOpenGraph ? 'Open Graph tags detected' : 'Open Graph tags missing'}

--- a/client/src/components/dashboard/HeaderChecks.tsx
+++ b/client/src/components/dashboard/HeaderChecks.tsx
@@ -1,22 +1,11 @@
 
 import React from 'react';
-import { Box, Typography, Alert, CircularProgress } from '@mui/material';
+import { Box, Typography, Alert } from '@mui/material';
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '../ui/table';
 import { useAnalysisContext } from '../../contexts/AnalysisContext';
 
 const HeaderChecks = () => {
-  const { data, loading, error } = useAnalysisContext();
-
-  if (loading) {
-    return (
-      <Box display="flex" justifyContent="center" alignItems="center" py={4}>
-        <CircularProgress />
-        <Typography variant="body1" sx={{ ml: 2 }}>
-          Analyzing security headers...
-        </Typography>
-      </Box>
-    );
-  }
+  const { data, error } = useAnalysisContext();
 
   if (error) {
     return (

--- a/client/src/components/dashboard/MobileResponsiveness.tsx
+++ b/client/src/components/dashboard/MobileResponsiveness.tsx
@@ -1,6 +1,6 @@
 
 import React from 'react';
-import { Box, Typography, Card, CardContent, LinearProgress, Alert, CircularProgress } from '@mui/material';
+import { Box, Typography, Card, CardContent, LinearProgress, Alert } from '@mui/material';
 import { useAnalysisContext } from '../../contexts/AnalysisContext';
 
 interface IssueCardProps {
@@ -23,18 +23,7 @@ const IssueCard: React.FC<IssueCardProps> = ({ title, description }) => (
 );
 
 const MobileResponsiveness = () => {
-  const { data, loading, error } = useAnalysisContext();
-
-  if (loading) {
-    return (
-      <Box display="flex" justifyContent="center" alignItems="center" py={4}>
-        <CircularProgress />
-        <Typography variant="body1" sx={{ ml: 2 }}>
-          Analyzing mobile responsiveness...
-        </Typography>
-      </Box>
-    );
-  }
+  const { data, error } = useAnalysisContext();
 
   if (error) {
     return (

--- a/client/src/components/dashboard/OverviewTab.tsx
+++ b/client/src/components/dashboard/OverviewTab.tsx
@@ -5,7 +5,6 @@ import {
   Typography,
   Card,
   CardContent,
-  CircularProgress,
   Alert,
 } from '@mui/material';
 import type { AnalysisResponse } from '@/types/analysis';
@@ -46,17 +45,6 @@ const OverviewTab: React.FC<OverviewTabProps> = ({ data, loading, error }) => {
     );
   }
 
-  // Show loading indicator only when no data at all
-  if (loading && !data) {
-    return (
-      <Box sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center', py: 8 }}>
-        <CircularProgress size={60} />
-        <Typography variant="h6" sx={{ ml: 2 }}>
-          Analyzing website...
-        </Typography>
-      </Box>
-    );
-  }
 
   const overview = data?.data?.overview || { overallScore: 0 };
   if (!overview.overallScore && overview.overallScore !== 0) return null;
@@ -131,16 +119,7 @@ const OverviewTab: React.FC<OverviewTabProps> = ({ data, loading, error }) => {
       />
 
       {/* Metric card grid */}
-      {overview ? (
-        <MetricCards metrics={metrics} onInfo={handleMetricInfo} />
-      ) : (
-        <Box sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center', py: 4 }}>
-          <CircularProgress size={40} />
-          <Typography variant="body1" sx={{ ml: 2 }}>
-            Loading metrics...
-          </Typography>
-        </Box>
-      )}
+      <MetricCards metrics={metrics} onInfo={handleMetricInfo} />
 
       {/* Popover for metric info (shows only when infoAnchor is set) */}
       <MetricInfoPopover anchorEl={infoAnchor} infoText={infoText} onClose={handleClosePopover} />
@@ -152,21 +131,12 @@ const OverviewTab: React.FC<OverviewTabProps> = ({ data, loading, error }) => {
         </Typography>
         <Card sx={{ borderRadius: 2 }}>
           <CardContent sx={{ p: 3 }}>
-            {overview ? (
-              <Typography variant="body1" paragraph>
-                Analysis completed at {data?.timestamp ? new Date(data.timestamp).toLocaleString() : 'Unknown time'}.
-                {(overview?.overallScore ?? 0) >= 80
-                  ? ' The page shows excellent performance across most metrics.'
-                  : ' The page has room for improvement in several areas.'}
-              </Typography>
-            ) : (
-              <Box sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center', py: 2 }}>
-                <CircularProgress size={30} />
-                <Typography variant="body1" sx={{ ml: 2 }}>
-                  Generating analysis summary...
-                </Typography>
-              </Box>
-            )}
+            <Typography variant="body1" paragraph>
+              Analysis completed at {data?.timestamp ? new Date(data.timestamp).toLocaleString() : 'Unknown time'}.
+              {(overview?.overallScore ?? 0) >= 80
+                ? ' The page shows excellent performance across most metrics.'
+                : ' The page has room for improvement in several areas.'}
+            </Typography>
           </CardContent>
         </Card>
       </Box>
@@ -178,16 +148,7 @@ const OverviewTab: React.FC<OverviewTabProps> = ({ data, loading, error }) => {
         </Typography>
         <Card sx={{ borderRadius: 2 }}>
           <CardContent sx={{ p: 3 }}>
-            {overview ? (
-              <KeyFindingsGrid overview={overview.overallScore ? overview : { overallScore: 0 }} theme={theme} />
-            ) : (
-              <Box sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center', py: 2 }}>
-                <CircularProgress size={30} />
-                <Typography variant="body1" sx={{ ml: 2 }}>
-                  Analyzing key findings...
-                </Typography>
-              </Box>
-            )}
+            <KeyFindingsGrid overview={overview.overallScore ? overview : { overallScore: 0 }} theme={theme} />
           </CardContent>
         </Card>
       </Box>

--- a/client/src/components/dashboard/PerformanceTab.tsx
+++ b/client/src/components/dashboard/PerformanceTab.tsx
@@ -4,7 +4,6 @@ import {
   Typography,
   Card,
   CardContent,
-  CircularProgress,
   Alert,
   Tooltip,
   Slider,
@@ -101,7 +100,6 @@ const PerformanceTab: React.FC<PerformanceTabProps> = ({ data, loading, error })
     ? { lcpMs: coreWebVitalsArray[0]?.lcp || 0, inpMs: coreWebVitalsArray[0]?.fid || 0, cls: coreWebVitalsArray[0]?.cls || 0 }
     : coreWebVitalsArray || { lcpMs: 0, inpMs: 0, cls: 0 };
   
-  const showLoadingForPerformance = loading || !coreWebVitals;
 
   // Convert Core Web Vitals object to chart data
   const vitalsChartData = [
@@ -141,22 +139,14 @@ const PerformanceTab: React.FC<PerformanceTabProps> = ({ data, loading, error })
               </Typography>
             </Box>
             
-            {showLoadingForPerformance ? (
-              <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'center', py: 4 }}>
-                <CircularProgress size={32} sx={{ color: 'primary.main', mr: 2 }} />
-                <Typography variant="body2" color="text.secondary">
-                  Loading performance metrics...
-                </Typography>
-              </Box>
-            ) : (
-              <>
-                <Box sx={{ mb: 3 }}>
-                  <Box sx={{ display: 'flex', justifyContent: 'space-between', mb: 1 }}>
-                    <Typography variant="body2">Performance Score</Typography>
-                    <Typography variant="h4" sx={{ color: getScoreColor(performanceScore, theme) }}>
-                      {performanceScore}
-                    </Typography>
-                  </Box>
+            <>
+              <Box sx={{ mb: 3 }}>
+                <Box sx={{ display: 'flex', justifyContent: 'space-between', mb: 1 }}>
+                  <Typography variant="body2">Performance Score</Typography>
+                  <Typography variant="h4" sx={{ color: getScoreColor(performanceScore, theme) }}>
+                    {performanceScore}
+                  </Typography>
+                </Box>
                   <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
                     {performanceScore >= 90 ? 'Excellent Performance' : 
                      performanceScore >= 70 ? 'Good Performance' : 'Needs Improvement'}
@@ -259,7 +249,6 @@ const PerformanceTab: React.FC<PerformanceTabProps> = ({ data, loading, error })
                   </Box>
                 )}
               </>
-            )}
           </CardContent>
         </Card>
         
@@ -272,15 +261,7 @@ const PerformanceTab: React.FC<PerformanceTabProps> = ({ data, loading, error })
                 Core Web Vitals
               </Typography>
             </Box>
-            {showLoadingForPerformance ? (
-              <Box display="flex" justifyContent="center" alignItems="center" height="300px">
-                <CircularProgress size={40} />
-                <Typography variant="body2" sx={{ ml: 2 }}>
-                  Loading Core Web Vitals...
-                </Typography>
-              </Box>
-            ) : (
-              <ChartContainer config={chartConfig} className="h-80 w-full">
+            <ChartContainer config={chartConfig} className="h-80 w-full">
                 <RechartsBarChart
                   data={vitalsChartData}
                   margin={{ top: 20, right: 30, left: 10, bottom: 5 }}
@@ -292,7 +273,6 @@ const PerformanceTab: React.FC<PerformanceTabProps> = ({ data, loading, error })
                   <Bar dataKey="benchmark" fill={theme.palette.grey[300]} />
                 </RechartsBarChart>
               </ChartContainer>
-            )}
           </CardContent>
         </Card>
       </Box>
@@ -307,27 +287,18 @@ const PerformanceTab: React.FC<PerformanceTabProps> = ({ data, loading, error })
                 Mobile Analysis
               </Typography>
             </Box>
-            {loading ? (
-              <Box sx={{ display: 'flex', alignItems: 'center', py: 2 }}>
-                <CircularProgress size={20} sx={{ mr: 1 }} />
-                <Typography variant="body2" color="text.secondary">
-                  Analyzing mobile responsiveness...
+            <>
+              <Box sx={{ display: 'flex', justifyContent: 'space-between', mb: 1 }}>
+                <Typography variant="body2">Mobile Score</Typography>
+                <Typography variant="h4" sx={{ color: getScoreColor(mobileScore, theme) }}>
+                  {mobileScore}%
                 </Typography>
               </Box>
-            ) : (
-              <>
-                <Box sx={{ display: 'flex', justifyContent: 'space-between', mb: 1 }}>
-                  <Typography variant="body2">Mobile Score</Typography>
-                  <Typography variant="h4" sx={{ color: getScoreColor(mobileScore, theme) }}>
-                    {mobileScore}%
-                  </Typography>
-                </Box>
-                <Typography variant="body2" color="text.secondary">
-                  {mobileScore >= 90 ? 'Excellent mobile experience' : 
-                   mobileScore >= 70 ? 'Good mobile experience' : 'Mobile needs improvement'}
-                </Typography>
-              </>
-            )}
+              <Typography variant="body2" color="text.secondary">
+                {mobileScore >= 90 ? 'Excellent mobile experience' :
+                 mobileScore >= 70 ? 'Good mobile experience' : 'Mobile needs improvement'}
+              </Typography>
+            </>
           </CardContent>
         </Card>
         
@@ -339,24 +310,15 @@ const PerformanceTab: React.FC<PerformanceTabProps> = ({ data, loading, error })
                 Recommendations
               </Typography>
             </Box>
-            {loading ? (
-              <Box sx={{ display: 'flex', alignItems: 'center', py: 2 }}>
-                <CircularProgress size={20} sx={{ mr: 1 }} />
-                <Typography variant="body2" color="text.secondary">
-                  Generating recommendations...
-                </Typography>
-              </Box>
-            ) : (
-              <>
-                <Typography variant="body2" sx={{ mb: 1 }}>
-                  Performance improvements available
-                </Typography>
-                <Typography variant="body2" color="text.secondary">
-                  {performanceScore >= 90 ? 'Site is well optimized' : 
-                   performanceScore >= 70 ? 'Some optimizations possible' : 'Multiple improvements needed'}
-                </Typography>
-              </>
-            )}
+            <>
+              <Typography variant="body2" sx={{ mb: 1 }}>
+                Performance improvements available
+              </Typography>
+              <Typography variant="body2" color="text.secondary">
+                {performanceScore >= 90 ? 'Site is well optimized' :
+                 performanceScore >= 70 ? 'Some optimizations possible' : 'Multiple improvements needed'}
+              </Typography>
+            </>
           </CardContent>
         </Card>
       </Box>

--- a/client/src/components/dashboard/PerformanceTabOld.tsx
+++ b/client/src/components/dashboard/PerformanceTabOld.tsx
@@ -5,7 +5,6 @@ import {
   Card,
   CardContent,
   LinearProgress,
-  CircularProgress,
   Alert,
   Chip,
   Tooltip,
@@ -36,29 +35,8 @@ const getScoreTooltip = (score: number) => {
 
 
 
-function CoreWebVitalsSection({ performance, loading = false }: { performance: AnalysisResponse["data"]["performance"]; loading?: boolean }) {
+function CoreWebVitalsSection({ performance }: { performance: AnalysisResponse["data"]["performance"] }) {
   const theme = useTheme();
-  
-  if (loading) {
-    return (
-      <Card sx={{ borderRadius: 2, height: '400px' }}>
-        <CardContent sx={{ p: 2, height: '100%' }}>
-          <Box sx={{ display: 'flex', alignItems: 'center', mb: 2 }}>
-            <BarChart size={24} color="#FF6B35" style={{ marginRight: 8 }} />
-            <Typography variant="h6" gutterBottom sx={{ fontWeight: 'bold', lineHeight: 1.2 }}>
-              Core Web Vitals
-            </Typography>
-          </Box>
-          <Box display="flex" justifyContent="center" alignItems="center" height="300px">
-            <CircularProgress size={40} />
-            <Typography variant="body2" sx={{ ml: 2 }}>
-              Loading Core Web Vitals...
-            </Typography>
-          </Box>
-        </CardContent>
-      </Card>
-    );
-  }
 
   const chartConfig = {
     value: { label: 'Your Site', color: '#FF6B35' },
@@ -225,28 +203,7 @@ function SecurityAuditsSection() {
 }
 
 function MobileResponsivenessSection() {
-  const { data, loading, error } = useAnalysisContext();
-
-  if (loading) {
-    return (
-      <Card sx={{ borderRadius: 2 }}>
-        <CardContent sx={{ p: 2 }}>
-          <Box display="flex" alignItems="center" mb={2}>
-            <Smartphone size={24} color="#FF6B35" style={{ marginRight: 8 }} />
-            <Typography variant="h6" sx={{ fontWeight: 'bold' }}>
-              Mobile Responsiveness Details
-            </Typography>
-          </Box>
-          <Box display="flex" justifyContent="center" alignItems="center" py={2}>
-            <CircularProgress size={24} />
-            <Typography variant="body2" sx={{ ml: 2 }}>
-              Analyzing mobile responsiveness...
-            </Typography>
-          </Box>
-        </CardContent>
-      </Card>
-    );
-  }
+  const { data, error } = useAnalysisContext();
 
   if (error) {
     return (
@@ -314,28 +271,7 @@ function MobileResponsivenessSection() {
 }
 
 function SecurityScoreSection() {
-  const { data, loading, error } = useAnalysisContext();
-
-  if (loading) {
-    return (
-      <Card sx={{ borderRadius: 2 }}>
-        <CardContent sx={{ p: 2 }}>
-          <Box display="flex" alignItems="center" mb={2}>
-            <Shield size={24} color="#FF6B35" style={{ marginRight: 8 }} />
-            <Typography variant="h6" sx={{ fontWeight: 'bold' }}>
-              Security Score Details
-            </Typography>
-          </Box>
-          <Box display="flex" justifyContent="center" alignItems="center" py={2}>
-            <CircularProgress size={24} />
-            <Typography variant="body2" sx={{ ml: 2 }}>
-              Analyzing security...
-            </Typography>
-          </Box>
-        </CardContent>
-      </Card>
-    );
-  }
+  const { data, error } = useAnalysisContext();
 
   if (error) {
     return (
@@ -484,8 +420,7 @@ const PerformanceTab: React.FC<PerformanceTabProps> = ({ data, loading, error })
     );
   }
 
-  // Show content immediately, with individual loading indicators for missing sections
-  const showLoadingForPerformance = loading || !data.data?.performance?.coreWebVitals || data.data.performance.coreWebVitals.length === 0;
+  // Show content immediately without section loading states
 
   const { performance } = data.data;
   const mobileScore = contextData?.mobileResponsiveness?.score || 0;
@@ -501,7 +436,7 @@ const PerformanceTab: React.FC<PerformanceTabProps> = ({ data, loading, error })
 
       {/* Main content - exactly like SEO tab pattern */}
       <Box sx={{ display: 'grid', gridTemplateColumns: { xs: '1fr', md: '2fr 1fr' }, gap: 2, mb: 2 }}>
-        <CoreWebVitalsSection performance={performance} loading={showLoadingForPerformance} />
+        <CoreWebVitalsSection performance={performance} />
         
         <Card sx={{ borderRadius: 2 }}>
           <CardContent sx={{ p: 2 }}>

--- a/client/src/components/dashboard/ResponsiveLayoutProbe.tsx
+++ b/client/src/components/dashboard/ResponsiveLayoutProbe.tsx
@@ -5,7 +5,6 @@ import {
   Card,
   CardContent,
   Button,
-  CircularProgress,
   Alert,
   Grid,
   Chip,
@@ -163,7 +162,7 @@ const ResponsiveLayoutProbe: React.FC<ResponsiveLayoutProbeProps> = ({ url }) =>
           <Button
             variant="contained"
             size="small"
-            startIcon={isProbing ? <CircularProgress size={16} color="inherit" /> : <RefreshCw size={16} />}
+            startIcon={<RefreshCw size={16} />}
             onClick={runResponsiveProbe}
             disabled={!url || isProbing}
           >
@@ -205,15 +204,6 @@ const ResponsiveLayoutProbe: React.FC<ResponsiveLayoutProbeProps> = ({ url }) =>
                         </Box>
                       </Box>
 
-                      {/* Loading State */}
-                      {device.loading && (
-                        <Box sx={{ display: 'flex', flexDirection: 'column', alignItems: 'center', py: 3 }}>
-                          <CircularProgress size={32} sx={{ mb: 2 }} />
-                          <Typography variant="body2" color="text.secondary">
-                            Analyzing {device.device.toLowerCase()} layout...
-                          </Typography>
-                        </Box>
-                      )}
 
                       {/* Error State */}
                       {device.error && (

--- a/client/src/components/dashboard/SEOAnalysisTab.tsx
+++ b/client/src/components/dashboard/SEOAnalysisTab.tsx
@@ -1,6 +1,6 @@
 
 import React from 'react';
-import { Box, Typography, Card, CardContent, Chip, CircularProgress, Alert, Tooltip, Table, TableBody, TableCell, TableContainer, TableHead, TableRow, Paper } from '@mui/material';
+import { Box, Typography, Card, CardContent, Chip, Alert, Tooltip, Table, TableBody, TableCell, TableContainer, TableHead, TableRow, Paper } from '@mui/material';
 import { CheckCircle, AlertCircle, XCircle, Search, Target, TrendingUp, Hash, FileText, Globe, Shield, Check, X } from 'lucide-react';
 import type { AnalysisResponse } from '@/types/analysis';
 import { useTheme } from '@mui/material/styles';
@@ -15,7 +15,6 @@ interface SEOAnalysisTabProps {
 const SEOAnalysisTab: React.FC<SEOAnalysisTabProps> = ({ data, loading, error }) => {
   const theme = useTheme();
   const seoData = data?.data?.seo;
-  const seoLoading = loading;
   const seoError = error;
 
   // Extract URL from the data
@@ -150,14 +149,7 @@ const SEOAnalysisTab: React.FC<SEOAnalysisTabProps> = ({ data, loading, error })
               </Typography>
             </Box>
             <Box>
-              {seoLoading ? (
-                <Box sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center', py: 3 }}>
-                  <CircularProgress size={32} sx={{ mr: 2 }} />
-                  <Typography variant="body2" color="text.secondary">
-                    Analyzing SEO checklist...
-                  </Typography>
-                </Box>
-              ) : seoError ? (
+              {seoError ? (
                 <Typography variant="body2" color="error" sx={{ fontStyle: 'italic', textAlign: 'center', py: 3 }}>
                   SEO analysis is temporarily unavailable. {seoError}
                 </Typography>
@@ -226,14 +218,7 @@ const SEOAnalysisTab: React.FC<SEOAnalysisTabProps> = ({ data, loading, error })
                   SEO Score
                 </Typography>
               </Box>
-              {seoLoading ? (
-                <Box sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center', py: 3 }}>
-                  <CircularProgress size={32} sx={{ mr: 2 }} />
-                  <Typography variant="body2" color="text.secondary">
-                    Calculating score...
-                  </Typography>
-                </Box>
-              ) : seoError ? (
+              {seoError ? (
                 <Typography variant="body2" color="error" sx={{ fontStyle: 'italic', py: 3 }}>
                   Score unavailable
                 </Typography>
@@ -279,14 +264,7 @@ const SEOAnalysisTab: React.FC<SEOAnalysisTabProps> = ({ data, loading, error })
                   Analysis Status
                 </Typography>
               </Box>
-              {seoLoading ? (
-                <Box sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center', py: 3 }}>
-                  <CircularProgress size={32} sx={{ mr: 2 }} />
-                  <Typography variant="body2" color="text.secondary">
-                    Analyzing status...
-                  </Typography>
-                </Box>
-              ) : seoError ? (
+              {seoError ? (
                 <Typography variant="body2" color="error" sx={{ fontStyle: 'italic', textAlign: 'center', py: 3 }}>
                   Status unavailable
                 </Typography>
@@ -353,21 +331,14 @@ const SEOAnalysisTab: React.FC<SEOAnalysisTabProps> = ({ data, loading, error })
               SEO Recommendations
             </Typography>
           </Box>
-          {seoLoading ? (
-            <Box sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center', py: 3 }}>
-              <CircularProgress size={32} sx={{ mr: 2 }} />
-              <Typography variant="body2" color="text.secondary">
-                Generating recommendations...
+            {seoError ? (
+              <Typography variant="body2" color="error" sx={{ fontStyle: 'italic', textAlign: 'center', py: 3 }}>
+                Recommendations unavailable
               </Typography>
-            </Box>
-          ) : seoError ? (
-            <Typography variant="body2" color="error" sx={{ fontStyle: 'italic', textAlign: 'center', py: 3 }}>
-              Recommendations unavailable
-            </Typography>
-          ) : !seoData ? (
-            <Typography variant="body2" color="text.secondary" sx={{ fontStyle: 'italic', textAlign: 'center', py: 3 }}>
-              Recommendations pending...
-            </Typography>
+            ) : !seoData ? (
+              <Typography variant="body2" color="text.secondary" sx={{ fontStyle: 'italic', textAlign: 'center', py: 3 }}>
+                Recommendations pending...
+              </Typography>
           ) : (
             <Box sx={{ display: 'grid', gridTemplateColumns: { xs: '1fr', md: 'repeat(2, 1fr)' }, gap: 2 }}>
               {seoData.recommendations?.map((rec, index) => (
@@ -426,14 +397,7 @@ const SEOAnalysisTab: React.FC<SEOAnalysisTabProps> = ({ data, loading, error })
                 Top Keywords
               </Typography>
             </Box>
-            {seoLoading ? (
-              <Box sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center', py: 3 }}>
-                <CircularProgress size={32} sx={{ mr: 2 }} />
-                <Typography variant="body2" color="text.secondary">
-                  Analyzing keywords...
-                </Typography>
-              </Box>
-            ) : seoError ? (
+            {seoError ? (
               <Typography variant="body2" color="error" sx={{ fontStyle: 'italic', textAlign: 'center', py: 3 }}>
                 Keywords unavailable
               </Typography>
@@ -477,14 +441,7 @@ const SEOAnalysisTab: React.FC<SEOAnalysisTabProps> = ({ data, loading, error })
                 Heading Structure
               </Typography>
             </Box>
-            {seoLoading ? (
-              <Box sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center', py: 3 }}>
-                <CircularProgress size={32} sx={{ mr: 2 }} />
-                <Typography variant="body2" color="text.secondary">
-                  Analyzing headings...
-                </Typography>
-              </Box>
-            ) : seoError ? (
+            {seoError ? (
               <Typography variant="body2" color="error" sx={{ fontStyle: 'italic', textAlign: 'center', py: 3 }}>
                 Heading analysis unavailable
               </Typography>
@@ -528,14 +485,7 @@ const SEOAnalysisTab: React.FC<SEOAnalysisTabProps> = ({ data, loading, error })
                 Technical SEO
               </Typography>
             </Box>
-            {seoLoading ? (
-              <Box sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center', py: 3 }}>
-                <CircularProgress size={32} sx={{ mr: 2 }} />
-                <Typography variant="body2" color="text.secondary">
-                  Checking technical SEO...
-                </Typography>
-              </Box>
-            ) : seoError ? (
+            {seoError ? (
               <Typography variant="body2" color="error" sx={{ fontStyle: 'italic', textAlign: 'center', py: 3 }}>
                 Technical SEO check unavailable
               </Typography>

--- a/client/src/components/dashboard/SecurityScore.tsx
+++ b/client/src/components/dashboard/SecurityScore.tsx
@@ -1,6 +1,6 @@
 
 import React from 'react';
-import { Box, Typography, Card, CardContent, Chip, Alert, CircularProgress } from '@mui/material';
+import { Box, Typography, Card, CardContent, Chip, Alert } from '@mui/material';
 import { useAnalysisContext } from '../../contexts/AnalysisContext';
 
 interface GradeBadgeProps {
@@ -48,18 +48,7 @@ const FindingItem: React.FC<FindingItemProps> = ({ title, description }) => (
 );
 
 const SecurityScore = () => {
-  const { data, loading, error } = useAnalysisContext();
-
-  if (loading) {
-    return (
-      <Box display="flex" justifyContent="center" alignItems="center" py={4}>
-        <CircularProgress />
-        <Typography variant="body1" sx={{ ml: 2 }}>
-          Analyzing security...
-        </Typography>
-      </Box>
-    );
-  }
+  const { data, error } = useAnalysisContext();
 
   if (error) {
     return (

--- a/client/src/components/dashboard/TechTab.tsx
+++ b/client/src/components/dashboard/TechTab.tsx
@@ -1,6 +1,6 @@
 
 import React from 'react';
-import { Box, Typography, Card, CardContent, Chip, CircularProgress, Alert, Tooltip } from '@mui/material';
+import { Box, Typography, Card, CardContent, Chip, Alert, Tooltip } from '@mui/material';
 import { Shield, Globe, Server, Database, Code, Layers, Zap, Activity, BarChart, Users, Cookie, Settings } from 'lucide-react';
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '../ui/table';
 import type { AnalysisResponse } from '@/types/analysis';
@@ -290,14 +290,6 @@ const TechTab: React.FC<TechTabProps> = ({ data, loading, error }) => {
   // Determine if we have any tech data at all (from either source)
   const hasTechData = !!(techData && Object.keys(techData).length > 0) || !!techAnalysis;
   
-  // Determine loading state for each section - only show loading if we're loading AND don't have any tech data
-  const isTechStackLoading = loading && displayTechStack.length === 0 && !hasTechData;
-  const isMinificationLoading = loading && !displayMinification && !hasTechData;
-  const isSocialLoading = loading && !displaySocial && !hasTechData;
-  // For Ad Tags and Cookies - don't show loading if we have any tech data (these might not be available in basic tech data)
-  const isAdTagsLoading = loading && !displayAdTags && !hasTechData && !techAnalysis;
-  const isCookiesLoading = loading && !displayCookies && !hasTechData && !techAnalysis;
-  const isIssuesLoading = loading && !techAnalysis && !techData?.issues && !hasTechData;
 
   // Only show error state if we have no data at all AND there's an error
   const shouldShowError = techError && !hasTechData;
@@ -328,14 +320,7 @@ const TechTab: React.FC<TechTabProps> = ({ data, loading, error }) => {
                   Tech Stack
                 </Typography>
               </Box>
-              {isTechStackLoading ? (
-                <Box sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center', py: 3 }}>
-                  <CircularProgress size={32} sx={{ mr: 2 }} />
-                  <Typography variant="body2" color="text.secondary">
-                    Analyzing technologies...
-                  </Typography>
-                </Box>
-              ) : shouldShowError ? (
+              {shouldShowError ? (
                 <Typography variant="body2" color="error" sx={{ fontStyle: 'italic', textAlign: 'center', py: 3 }}>
                   Technology analysis unavailable
                 </Typography>
@@ -363,14 +348,7 @@ const TechTab: React.FC<TechTabProps> = ({ data, loading, error }) => {
                   Minification Status
                 </Typography>
               </Box>
-              {isMinificationLoading ? (
-                <Box sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center', py: 3 }}>
-                  <CircularProgress size={32} sx={{ mr: 2 }} />
-                  <Typography variant="body2" color="text.secondary">
-                    Checking minification...
-                  </Typography>
-                </Box>
-              ) : shouldShowError ? (
+              {shouldShowError ? (
                 <Typography variant="body2" color="error" sx={{ fontStyle: 'italic', textAlign: 'center', py: 3 }}>
                   Minification check unavailable
                 </Typography>
@@ -433,14 +411,7 @@ const TechTab: React.FC<TechTabProps> = ({ data, loading, error }) => {
                 Tracking Pixels & Ad Tags
               </Typography>
             </Box>
-            {isAdTagsLoading ? (
-              <Box sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center', py: 3 }}>
-                <CircularProgress size={32} sx={{ mr: 2 }} />
-                <Typography variant="body2" color="text.secondary">
-                  Scanning for tracking pixels and ad tags...
-                </Typography>
-              </Box>
-            ) : shouldShowError ? (
+            {shouldShowError ? (
               <Typography variant="body2" color="error" sx={{ fontStyle: 'italic', textAlign: 'center', py: 3 }}>
                 Tracking pixel analysis unavailable
               </Typography>
@@ -501,14 +472,7 @@ const TechTab: React.FC<TechTabProps> = ({ data, loading, error }) => {
                 Detected Social Tags
               </Typography>
             </Box>
-            {isSocialLoading ? (
-              <Box sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center', py: 3 }}>
-                <CircularProgress size={32} sx={{ mr: 2 }} />
-                <Typography variant="body2" color="text.secondary">
-                  Scanning for social tags...
-                </Typography>
-              </Box>
-            ) : shouldShowError ? (
+            {shouldShowError ? (
               <Typography variant="body2" color="error" sx={{ fontStyle: 'italic', textAlign: 'center', py: 3 }}>
                 Social tag analysis unavailable
               </Typography>
@@ -582,14 +546,7 @@ const TechTab: React.FC<TechTabProps> = ({ data, loading, error }) => {
                 Detected Cookie Banner & Consent Script
               </Typography>
             </Box>
-            {isCookiesLoading ? (
-              <Box sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center', py: 3 }}>
-                <CircularProgress size={32} sx={{ mr: 2 }} />
-                <Typography variant="body2" color="text.secondary">
-                  Checking for cookies...
-                </Typography>
-              </Box>
-            ) : shouldShowError ? (
+            {shouldShowError ? (
               <Typography variant="body2" color="error" sx={{ fontStyle: 'italic', textAlign: 'center', py: 3 }}>
                 Cookie analysis unavailable
               </Typography>
@@ -666,14 +623,7 @@ const TechTab: React.FC<TechTabProps> = ({ data, loading, error }) => {
                   Technical Issues
                 </Typography>
               </Box>
-              {isIssuesLoading ? (
-                <Box sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center', py: 3 }}>
-                  <CircularProgress size={32} sx={{ mr: 2 }} />
-                  <Typography variant="body2" color="text.secondary">
-                    Analyzing technical issues...
-                  </Typography>
-                </Box>
-              ) : shouldShowError ? (
+              {shouldShowError ? (
                 <Typography variant="body2" color="error" sx={{ fontStyle: 'italic', textAlign: 'center', py: 3 }}>
                   Technical issue analysis unavailable
                 </Typography>

--- a/client/src/components/dashboard/UIAnalysisTab.tsx
+++ b/client/src/components/dashboard/UIAnalysisTab.tsx
@@ -1,13 +1,12 @@
 
 import React from 'react';
-import { Box, Typography, Card, CardContent, CircularProgress, Alert } from '@mui/material';
+import { Box, Typography, Card, CardContent, Alert } from '@mui/material';
 import type { AnalysisResponse } from '@/types/analysis';
 import ColorExtractionCard from './ui-analysis/ColorExtractionCard';
 import FontAnalysisCard from './ui-analysis/FontAnalysisCard';
 import ImageAnalysisCard from './ui-analysis/ImageAnalysisCard';
 import AccessibilityCard from './ui-analysis/AccessibilityCard';
 import LegendContainer from './LegendContainer';
-import SkeletonCard from '../ui/SkeletonCard';
 
 interface UIAnalysisTabProps {
   data: AnalysisResponse | null;
@@ -21,10 +20,6 @@ const UIAnalysisTab: React.FC<UIAnalysisTabProps> = ({ data, loading, error }) =
 
   // Use data directly from unified overview endpoint
   // Show loading when actually loading and no complete data available
-  const showLoadingForColors = loading && (!colors || colors.length === 0);
-  const showLoadingForFonts = loading && (!fonts || fonts.length === 0);
-  const showLoadingForAccessibility = loading && (!accessibilityScore && !contrastIssues?.length && !violations?.length);
-  const showLoadingForImages = loading && (!images || images.length === 0);
 
   if (error) {
     return (
@@ -45,25 +40,9 @@ const UIAnalysisTab: React.FC<UIAnalysisTabProps> = ({ data, loading, error }) =
         {/* Color Extraction */}
         <Card sx={{ borderRadius: 2, width: '100%' }}>
           <CardContent sx={{ p: 2 }}>
-            {showLoadingForColors ? (
-              <Box>
-                <Box sx={{ display: 'flex', alignItems: 'center', mb: 3 }}>
-                  <Typography variant="h6">
-                    Color Extraction
-                  </Typography>
-                </Box>
-                <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'center', py: 4 }}>
-                  <CircularProgress size={32} sx={{ color: 'primary.main', mr: 2 }} />
-                  <Typography variant="body2" color="text.secondary">
-                    Extracting colors from website...
-                  </Typography>
-                </Box>
-              </Box>
-            ) : (
-              <ColorExtractionCard 
-                colors={colors || []} 
-              />
-            )}
+            <ColorExtractionCard
+              colors={colors || []}
+            />
           </CardContent>
         </Card>
 
@@ -71,57 +50,27 @@ const UIAnalysisTab: React.FC<UIAnalysisTabProps> = ({ data, loading, error }) =
         <Box sx={{ display: 'grid', gridTemplateColumns: { xs: '1fr', md: '1fr 1fr' }, gap: 2 }}>
           <Card sx={{ borderRadius: 2, width: '100%' }}>
             <CardContent sx={{ p: 2 }}>
-              {showLoadingForFonts ? (
-                <Box>
-                  <Box sx={{ display: 'flex', alignItems: 'center', mb: 3 }}>
-                    <Typography variant="h6">
-                      Font Analysis
-                    </Typography>
-                  </Box>
-                  <Box sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center', py: 3 }}>
-                    <CircularProgress size={32} sx={{ mr: 2 }} />
-                    <Typography variant="body2" color="text.secondary">
-                      Extracting fonts...
-                    </Typography>
-                  </Box>
-                </Box>
-              ) : (
-                <FontAnalysisCard 
-                  fonts={fonts ?? []} 
-                />
-              )}
+              <FontAnalysisCard
+                fonts={fonts ?? []}
+              />
             </CardContent>
           </Card>
 
           <Card sx={{ borderRadius: 2, width: '100%' }}>
             <CardContent sx={{ p: 2 }}>
-              {showLoadingForAccessibility ? (
-                <Box>
-                  <Box sx={{ display: 'flex', alignItems: 'center', mb: 3 }}>
-                    <Typography variant="h6">
-                      Accessibility & Contrast
-                    </Typography>
-                  </Box>
-                  <Box sx={{ display: 'flex', alignItems: 'center', py: 4 }}>
-                    <CircularProgress size={24} sx={{ mr: 2 }} />
-                    <Typography variant="body2">Analyzing accessibility...</Typography>
-                  </Box>
-                </Box>
-              ) : (
-                <AccessibilityCard 
-                  contrastIssues={contrastIssues?.map(issue => ({
-                    element: issue.element || 'unknown',
-                    textColor: issue.textColor || issue.foregroundColor || '#000',
-                    backgroundColor: issue.backgroundColor || '#fff',
-                    ratio: issue.ratio || 0,
-                    expectedRatio: 4.5,
-                    severity: 'warning',
-                    recommendation: 'Improve color contrast'
-                  })) || []}
-                  accessibilityScore={accessibilityScore}
-                  violations={violations}
-                />
-              )}
+              <AccessibilityCard
+                contrastIssues={contrastIssues?.map(issue => ({
+                  element: issue.element || 'unknown',
+                  textColor: issue.textColor || issue.foregroundColor || '#000',
+                  backgroundColor: issue.backgroundColor || '#fff',
+                  ratio: issue.ratio || 0,
+                  expectedRatio: 4.5,
+                  severity: 'warning',
+                  recommendation: 'Improve color contrast'
+                })) || []}
+                accessibilityScore={accessibilityScore}
+                violations={violations}
+              />
             </CardContent>
           </Card>
         </Box>
@@ -129,26 +78,10 @@ const UIAnalysisTab: React.FC<UIAnalysisTabProps> = ({ data, loading, error }) =
         {/* Image Analysis */}
         <Card sx={{ borderRadius: 2, width: '100%' }}>
           <CardContent sx={{ p: 2 }}>
-            {showLoadingForImages ? (
-              <Box>
-                <Box sx={{ display: 'flex', alignItems: 'center', mb: 3 }}>
-                  <Typography variant="h6">
-                    Image Analysis
-                  </Typography>
-                </Box>
-                <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'center', py: 4 }}>
-                  <CircularProgress size={32} sx={{ mr: 2 }} />
-                  <Typography variant="body2" color="text.secondary">
-                    Analyzing images...
-                  </Typography>
-                </Box>
-              </Box>
-            ) : (
-              <ImageAnalysisCard
-                images={images ?? []}
-                imageAnalysis={imageAnalysis}
-              />
-            )}
+            <ImageAnalysisCard
+              images={images ?? []}
+              imageAnalysis={imageAnalysis}
+            />
           </CardContent>
         </Card>
       </Box>

--- a/client/src/components/dashboard/shared/MetricCard.tsx
+++ b/client/src/components/dashboard/shared/MetricCard.tsx
@@ -6,7 +6,6 @@ import {
   CardContent,
   IconButton,
   Tooltip,
-  CircularProgress,
 } from '@mui/material';
 import InfoOutlined from '@mui/icons-material/InfoOutlined';
 import { LucideIcon } from 'lucide-react';
@@ -133,24 +132,15 @@ export const MetricCard: React.FC<MetricCardProps> = ({
             >
               <IconComponent size={24} />
             </Box>
-            {loading ? (
-              <Box sx={{ display: 'flex', alignItems: 'center' }}>
-                <CircularProgress size={16} sx={{ mr: 1 }} />
-                <Typography variant="body2" color="text.secondary">
-                  Loading...
-                </Typography>
-              </Box>
-            ) : (
-              <Tooltip 
-                title={finalTooltip}
-                enterDelay={300}
-                enterTouchDelay={300}
-              >
-                <Typography variant="h6" component="div" sx={{ fontWeight: 'bold', cursor: 'help' }}>
-                  {value}
-                </Typography>
-              </Tooltip>
-            )}
+            <Tooltip
+              title={finalTooltip}
+              enterDelay={300}
+              enterTouchDelay={300}
+            >
+              <Typography variant="h6" component="div" sx={{ fontWeight: 'bold', cursor: 'help' }}>
+                {value}
+              </Typography>
+            </Tooltip>
           </Box>
           {/* Description */}
           <Typography variant="body2" color="text.secondary">
@@ -171,27 +161,18 @@ export const MetricCard: React.FC<MetricCardProps> = ({
             {finalTitleLines.join(' ')}
           </Typography>
         </Box>
-        {loading ? (
-          <Box sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center', mb: 1 }}>
-            <CircularProgress size={24} sx={{ mr: 1 }} />
-            <Typography variant="body2" color="text.secondary">
-              Loading...
-            </Typography>
-          </Box>
-        ) : (
-          <Tooltip 
-            title={finalTooltip}
-            enterDelay={300}
-            enterTouchDelay={300}
+        <Tooltip
+          title={finalTooltip}
+          enterDelay={300}
+          enterTouchDelay={300}
+        >
+          <Typography
+            variant={title === 'Performance Score' ? 'h2' : 'h3'}
+            sx={{ fontWeight: 'bold', color, textAlign: 'center', mb: 1, cursor: 'help' }}
           >
-            <Typography
-              variant={title === 'Performance Score' ? 'h2' : 'h3'}
-              sx={{ fontWeight: 'bold', color, textAlign: 'center', mb: 1, cursor: 'help' }}
-            >
-              {value}
-            </Typography>
-          </Tooltip>
-        )}
+            {value}
+          </Typography>
+        </Tooltip>
         <Typography variant="body2" color="text.secondary" sx={{ textAlign: 'center' }}>
           {description}
         </Typography>

--- a/client/src/components/dashboard/ui-analysis/AccessibilityCard.tsx
+++ b/client/src/components/dashboard/ui-analysis/AccessibilityCard.tsx
@@ -2,8 +2,7 @@ import React, { useState, useEffect } from 'react';
 import { 
   Box, 
   Typography, 
-  LinearProgress, 
-  CircularProgress,
+  LinearProgress,
   Chip,
   Alert,
   Collapse,

--- a/client/src/components/dashboard/ui-analysis/ColorExtractionCard.tsx
+++ b/client/src/components/dashboard/ui-analysis/ColorExtractionCard.tsx
@@ -3,7 +3,7 @@
  * Now supports 11 semantic color buckets for comprehensive analysis.
  */
 import React, { useState, useEffect, useRef } from 'react';
-import { Box, Typography, Collapse, IconButton, CircularProgress, Alert, Dialog, DialogContent, SxProps, Theme, Popover, FormControlLabel, Checkbox, FormGroup, useTheme } from '@mui/material';
+import { Box, Typography, Collapse, IconButton, Alert, Dialog, DialogContent, SxProps, Theme, Popover, FormControlLabel, Checkbox, FormGroup, useTheme } from '@mui/material';
 import { Palette, ChevronDown, ChevronUp, Settings } from 'lucide-react';
 
 const SECTION_ORDER = [
@@ -253,14 +253,7 @@ export default function ColorExtractionCard({ colors }: ColorExtractionCardProps
       </Box>
       
       <Box>
-        {loading ? (
-          <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'center', py: 4 }}>
-            <CircularProgress size={32} sx={{ color: 'primary.main', mr: 2 }} />
-            <Typography variant="body2" color="text.secondary">
-              Extracting colors from website...
-            </Typography>
-          </Box>
-        ) : error ? (
+        {error ? (
           <Alert severity="error" sx={{ mt: 2 }}>
             {error}
           </Alert>

--- a/client/src/components/dashboard/ui-analysis/FontAnalysisCard.tsx
+++ b/client/src/components/dashboard/ui-analysis/FontAnalysisCard.tsx
@@ -1,6 +1,6 @@
 
 import React, { useState, useEffect, useRef } from 'react';
-import { Box, Typography, Chip, CircularProgress, useTheme } from '@mui/material';
+import { Box, Typography, Chip, useTheme } from '@mui/material';
 import { Type } from 'lucide-react';
 import type { AnalysisResponse } from '@/types/analysis';
 


### PR DESCRIPTION
## Summary
- strip all loading states and placeholders in dashboard
- simplify dashboard feature cards and remove dead props

## Testing
- `npm run lint` *(fails: Could not read package.json)*
- `npm run typecheck` *(fails: Could not read package.json)*
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6882f9cd4e78832b87d4c9a1fcadbd02