### PR TITLE
Update replit workflow to start worker

### DIFF
--- a/.replit
+++ b/.replit
@@ -47,5 +47,5 @@ author = "agent"
 
 [[workflows.workflow.tasks]]
 task = "shell.exec"
-args = "npm run dev"
+args = "concurrently \"npm run dev\" \"npx tsx worker/index.ts\" --names \"app,worker\" --prefix-colors \"blue,green\""
 waitForPort = 5000


### PR DESCRIPTION
## Summary
- adjust `.replit` to run both the app and the worker concurrently

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68882aa225c0832b88b9802a39442ac1