### PR TITLE
Add scan_tasks model and docs

### DIFF
--- a/docs/SUPABASE_SCHEMA.md
+++ b/docs/SUPABASE_SCHEMA.md
@@ -25,12 +25,20 @@ Based on the actual database structure, here are the tables and their exact colu
 • **updated_at** (timestamp without time zone) – last update timestamp
 
 ## scans
-• **id** (uuid PK) – auto‑generated via `uuid_generate_v4()`  
-• **user_id** (uuid) – FK → `auth.users.id`, nullable for anonymous scans  
-• **url** (text) – the URL to be scanned  
-• **created_at** (timestamp without time zone) – when the scan was requested  
-• **last_run_at** (timestamp without time zone) – timestamp of last scan execution  
+• **id** (uuid PK) – auto‑generated via `uuid_generate_v4()`
+• **user_id** (uuid) – FK → `auth.users.id`, nullable for anonymous scans
+• **url** (text) – the URL to be scanned
+• **created_at** (timestamp without time zone) – when the scan was requested
+• **last_run_at** (timestamp without time zone) – timestamp of last scan execution
 • **active** (boolean) – whether the scan is active (soft‑delete flag)
+
+### scan_tasks
+• **task_id** (uuid PK) – unique ID for each sub-task  
+• **scan_id** (uuid FK → scans.id) – parent scan reference  
+• **type** (text) – one of `tech`, `colors`, `seo`, `perf`  
+• **status** (text) – `queued`|`running`|`complete`|`failed`  
+• **payload** (jsonb) – parameters or result metadata  
+• **created_at** (timestamptz) – default `now()`
 
 ## Additional Tables
 The database also contains these tables:

--- a/docs/TECH_STACK.md
+++ b/docs/TECH_STACK.md
@@ -95,6 +95,7 @@ We persist and manage scans using Supabase tables. See [`docs/SUPABASE_SCHEMA.md
 - **scans**: stores all scan requests.
 - **scan_status**: tracks queue/running/completion per scan.
 - **analysis_cache**: stores JSON audit blobs for reuse.
+- **scan_tasks**: queue table for individual analyzers per scan (see SUPABASE_SCHEMA.md)
 
 ### Utility & Helper Libraries
 

--- a/migrations/20250729_add_scan_tasks.sql
+++ b/migrations/20250729_add_scan_tasks.sql
@@ -1,0 +1,9 @@
+CREATE TABLE IF NOT EXISTS public.scan_tasks (
+  task_id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+  scan_id UUID NOT NULL REFERENCES public.scans(id) ON DELETE CASCADE,
+  type TEXT NOT NULL,
+  status TEXT NOT NULL DEFAULT 'queued',
+  payload JSONB,
+  created_at timestamptz NOT NULL DEFAULT now()
+);
+CREATE INDEX IF NOT EXISTS scan_tasks_scan_type_idx ON public.scan_tasks(scan_id, type);

--- a/server/api/scans.ts
+++ b/server/api/scans.ts
@@ -1,6 +1,6 @@
 import { FastifyInstance } from 'fastify';
 import { db } from '../db.js';
-import { analysisCache, scanStatus, scanTasks } from '../../shared/schema.js';
+import { scanTasks, scanStatus, analysisCache } from '../../shared/schema.js';
 import { eq, and } from 'drizzle-orm';
 import * as schema from '../../shared/schema.js';
 import { nanoid } from 'nanoid';

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -1,4 +1,4 @@
-import { pgTable, text, serial, uuid, timestamp, jsonb, boolean, smallint } from "drizzle-orm/pg-core";
+import { pgTable, text, serial, uuid, timestamp, timestamptz, jsonb, boolean, smallint } from "drizzle-orm/pg-core";
 import { createInsertSchema } from "drizzle-zod";
 import { z } from "zod";
 
@@ -50,15 +50,20 @@ export const analysisCache = pgTable("analysis_cache", {
 // scan_tasks
 export const scanTasks = pgTable("scan_tasks", {
   taskId: uuid("task_id").primaryKey().defaultRandom(),
-  scanId: uuid("scan_id").references(() => scans.id, { onDelete: "cascade" }),
+  scanId: uuid("scan_id")
+    .notNull()
+    .references(() => scans.id, { onDelete: "cascade" }),
   type: text("type")
     .$type<"tech" | "colors" | "seo" | "perf">()
     .notNull(),
   status: text("status")
     .$type<"queued" | "running" | "complete" | "failed">()
+    .notNull()
     .default("queued"),
   payload: jsonb("payload"),
-  createdAt: timestamp("created_at").defaultNow(),
+  createdAt: timestamptz("created_at")
+    .notNull()
+    .defaultNow(),
 });
 
 export const insertUserSchema = createInsertSchema(users).pick({


### PR DESCRIPTION
## Summary
- update scanTasks model with timestamptz and not null scanId
- include scan tasks details in Supabase docs
- mention scan_tasks table in tech stack
- adjust API imports and worker code
- add migration for new scan_tasks table

## Testing
- `npm run migrate:supabase` *(fails: drizzle-kit not installed)*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6889d52eea78832bb7aa5b60248f875b