### PR TITLE
Fix AnalysisResponse and scan_status schema

### DIFF
--- a/client/src/hooks/useScanStatus.ts
+++ b/client/src/hooks/useScanStatus.ts
@@ -6,6 +6,7 @@ export interface ScanStatus {
   progress: number;
   scanId: string;
   url?: string;
+  finishedAt?: string;
 }
 
 export function useScanStatus(scanId: string) {

--- a/client/src/types/analysis.ts
+++ b/client/src/types/analysis.ts
@@ -39,7 +39,7 @@ export interface AnalysisOverview {
 }
 
 export interface AnalysisResponse {
-  success: boolean;
+  success?: boolean;
   id?: string;
   url?: string;
   timestamp?: string;
@@ -69,6 +69,22 @@ export interface AnalysisResponse {
   accessibility?: {
     violations: any[];
   };
+  overview?: AnalysisOverview;
+  tech?: {
+    techStack?: any[];
+    minification?: { cssMinified: boolean; jsMinified: boolean };
+    social?: any;
+    cookies?: any;
+    adTags?: any[];
+    issues?: any[];
+  };
+  colors?: any[];
+  fonts?: any[];
+  images?: any[];
+  imageAnalysis?: any;
+  contrastIssues?: any[];
+  violations?: any[];
+  accessibilityScore?: number;
   headerChecks?: {
     hsts: string;
     csp: string;
@@ -96,7 +112,7 @@ export interface AnalysisResponse {
       [key: string]: any;
     };
 
-    technical: {
+    technical?: {
       accessibility: {
         violations: Array<{
           id: string;
@@ -125,7 +141,29 @@ export interface AnalysisResponse {
       issues?: any[];
       securityScore?: number;
     };
-    performance: {
+    tech?: {
+      techStack?: any[];
+      minification?: { cssMinified: boolean; jsMinified: boolean };
+      social?: any;
+      cookies?: any;
+      adTags?: any[];
+      issues?: any[];
+    };
+    colors?: Array<{name: string, hex: string, usage: string, count: number}>;
+    fonts?: Array<{name: string, category: string, usage: string, weight?: string, isLoaded?: boolean, isPublic?: boolean}>;
+    images?: Array<{url: string, alt?: string, type?: string}>;
+    imageAnalysis?: {
+      totalImages: number;
+      estimatedPhotos: number;
+      estimatedIcons: number;
+      imageUrls?: string[];
+      photoUrls?: string[];
+      iconUrls?: string[];
+    };
+    contrastIssues?: Array<{textColor: string, backgroundColor: string, ratio: number}>;
+    violations?: Array<{ id: string; impact?: string; description?: string }>;
+    accessibilityScore?: number;
+    performance?: {
       performanceScore: number;
       coreWebVitals: CoreWebVitals[];
       mobileResponsive?: boolean;
@@ -207,7 +245,7 @@ export interface AnalysisResponse {
       readabilityScore: number | string;
     };
   };
-  lhr: {
+  lhr?: {
     categories: {
       security: {
         score: number;

--- a/migrations/20250730_add_finished_at.sql
+++ b/migrations/20250730_add_finished_at.sql
@@ -1,0 +1,2 @@
+ALTER TABLE IF NOT EXISTS public.scan_status
+  ADD COLUMN IF NOT EXISTS finished_at timestamp;

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -1,4 +1,4 @@
-import { pgTable, text, serial, uuid, timestamp, timestamptz, jsonb, boolean, smallint } from "drizzle-orm/pg-core";
+import { pgTable, text, serial, uuid, timestamp, jsonb, boolean, smallint } from "drizzle-orm/pg-core";
 import { createInsertSchema } from "drizzle-zod";
 import { z } from "zod";
 
@@ -61,7 +61,7 @@ export const scanTasks = pgTable("scan_tasks", {
     .notNull()
     .default("queued"),
   payload: jsonb("payload"),
-  createdAt: timestamptz("created_at")
+  createdAt: timestamp("created_at")
     .notNull()
     .defaultNow(),
 });


### PR DESCRIPTION
## Summary
- extend `AnalysisResponse` with UI/tech fields used by the dashboard
- expose optional `finishedAt` in the scan status hook
- fix schema timestamp import and migration for `finished_at`

## Testing
- `npx tsc --noEmit --incremental false` *(fails: Property 'techStack' does not exist on type 'never', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6889e0d3c068832b8923ba36cdc61c60