### PR TITLE
Fix MUI Grid and Drizzle timestamp schema

### DIFF
--- a/client/src/components/dashboard/ResponsiveLayoutProbe.tsx
+++ b/client/src/components/dashboard/ResponsiveLayoutProbe.tsx
@@ -188,7 +188,7 @@ const ResponsiveLayoutProbe: React.FC<ResponsiveLayoutProbeProps> = ({ url }) =>
               const DeviceIcon = devices.find(d => d.name === device.device)?.icon || Monitor;
               
               return (
-                <Grid size={{ xs: 12, md: 4 }} key={device.device}>
+                <Grid component="div" size={{ xs: 12, md: 4 }} key={device.device}>
                   <Card variant="outlined" sx={{ height: '100%' }}>
                     <CardContent sx={{ p: 2 }}>
                       {/* Device Header */}

--- a/client/src/pages/Dashboard.tsx
+++ b/client/src/pages/Dashboard.tsx
@@ -89,7 +89,7 @@ const Dashboard = ({ darkMode, toggleDarkMode }: DashboardProps) => {
                 {taskTypes.map((taskType) => {
                   const hook = taskHooks[taskType];
                   return (
-                    <Grid item xs={12} md={6} key={taskType}>
+                    <Grid component="div" size={{ xs: 12, md: 6 }} key={taskType}>
                       <TaskCard
                         type={taskType}
                         data={hook.data}

--- a/client/src/pages/ProgressTestPage.tsx
+++ b/client/src/pages/ProgressTestPage.tsx
@@ -75,7 +75,7 @@ const ProgressTestPage = ({ darkMode, toggleDarkMode }: ProgressTestPageProps) =
 
           <Grid container spacing={3}>
             {/* Test Controls */}
-            <Grid item xs={12} md={6}>
+            <Grid component="div" size={{ xs: 12, md: 6 }}>
               <Card sx={{ p: 3 }}>
                 <Typography variant="h6" gutterBottom>
                   Create Test Scan
@@ -113,7 +113,7 @@ const ProgressTestPage = ({ darkMode, toggleDarkMode }: ProgressTestPageProps) =
             </Grid>
 
             {/* Live Progress Demo */}
-            <Grid item xs={12} md={6}>
+            <Grid component="div" size={{ xs: 12, md: 6 }}>
               <Card sx={{ p: 3 }}>
                 <Typography variant="h6" gutterBottom>
                   Live Progress Demo

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -1,4 +1,4 @@
-import { pgTable, text, serial, uuid, timestamp, timestamptz, jsonb, boolean, smallint } from "drizzle-orm/pg-core";
+import { pgTable, text, serial, uuid, timestamp, jsonb, boolean, smallint } from "drizzle-orm/pg-core";
 import { createInsertSchema } from "drizzle-zod";
 import { z } from "zod";
 
@@ -61,7 +61,7 @@ export const scanTasks = pgTable("scan_tasks", {
     .notNull()
     .default("queued"),
   payload: jsonb("payload"),
-  createdAt: timestamptz("created_at")
+  createdAt: timestamp("created_at", { mode: "date" })
     .notNull()
     .defaultNow(),
 });


### PR DESCRIPTION
## Summary
- fix MUI Grid props by adding `component="div"` and using the new `size` API
- replace removed `timestamptz` import with `timestamp`

## Testing
- `npx tsc --noEmit` *(fails: Property errors in TechTab etc.)*
- `npm run dev` *(fails: terminated)*
- `npm run worker:dev` *(fails: missing env vars)*

------
https://chatgpt.com/codex/tasks/task_e_6889e1d08148832b89ec871825f569fe