### PR TITLE
Remove Neon DB references

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,5 @@
-# Supabase Configuration (Primary Database)
-VITE_SUPABASE_URL=https://sxrhpwmdslxgwpqfdmxu.supabase.co
+# Supabase Configuration
+VITE_SUPABASE_URL=https://<project-ref>.supabase.co
 VITE_SUPABASE_ANON_KEY=your-anon-key-here
 SUPABASE_SERVICE_ROLE_KEY=your-service-role-key-here
-
-# Note: DATABASE_URL is no longer used - Supabase is the primary database
+DATABASE_URL=postgresql://<credentials>@db.<project-ref>.supabase.co:6543/postgres

--- a/package-lock.json
+++ b/package-lock.json
@@ -7563,7 +7563,6 @@
         "@electric-sql/pglite": ">=0.2.0",
         "@libsql/client": ">=0.10.0",
         "@libsql/client-wasm": ">=0.10.0",
-        "@neondatabase/serverless": ">=0.10.0",
         "@op-engineering/op-sqlite": ">=2",
         "@opentelemetry/api": "^1.4.1",
         "@planetscale/database": ">=1",
@@ -7599,9 +7598,6 @@
           "optional": true
         },
         "@libsql/client-wasm": {
-          "optional": true
-        },
-        "@neondatabase/serverless": {
           "optional": true
         },
         "@op-engineering/op-sqlite": {

--- a/replit.md
+++ b/replit.md
@@ -397,13 +397,13 @@ A comprehensive website analysis tool that provides insights into performance, S
 - ✓ Worker successfully processing queued tasks: 28+ tasks completed, analysis_cache populated
 - ✓ Created comprehensive Vitest test suite for scan API endpoints with mock JWT authentication
 - ✓ Both main application and background worker now running concurrently for full functionality
-- ✓ Diagnosed database connection issue: Application writes to Neon PostgreSQL, user views Supabase dashboard (July 29, 2025)
+- ✓ Diagnosed database connection issue: application wrote to the old database while viewing Supabase dashboard (July 29, 2025)
 - ✓ System working correctly: 11+ scans processed, 44+ tasks completed, Reddit scan processed successfully
 - ✓ Worker actively processing queued tasks with 100% completion rate for all scan types (tech, colors, seo, perf)
-- ✓ All tables exist and populated in Neon database: scans, scan_status, scan_tasks, analysis_cache
-- ✓ **BREAKING CHANGE: Completely removed Neon PostgreSQL, migrated to Supabase + Drizzle only** (July 29, 2025)
+- ✓ All tables exist and populated in the old database: scans, scan_status, scan_tasks, analysis_cache
+- ✓ **BREAKING CHANGE: Migrated to Supabase + Drizzle only** (July 29, 2025)
 - ✓ Updated server/db.ts to use postgres-js driver with direct Supabase PostgreSQL connection  
-- ✓ Removed @neondatabase/serverless dependency and all Neon references from codebase
+- ✓ Removed obsolete serverless dependencies and references to the old provider
 - ✓ Fixed TypeScript compilation errors in server/index.ts color extraction logic
 - ✓ Successfully tested Supabase connection: 1+ scan already in database, Drizzle queries working
 - ✓ Express server running on port 5000 with Supabase backend, ready for worker processing

--- a/server/index.ts
+++ b/server/index.ts
@@ -3,6 +3,12 @@ import { createServer } from "http";
 import { setupVite, serveStatic, log } from "./vite";
 import cors from "cors";
 
+if (!process.env.DATABASE_URL) {
+  throw new Error(
+    "DATABASE_URL not set. Please configure the Supabase connection string."
+  );
+}
+
 const app = express();
 const server = createServer(app);
 

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 set -e
+if [ -z "$DATABASE_URL" ]; then
+  echo "DATABASE_URL not set. Please configure the Supabase connection string."
+  exit 1
+fi
 rm -rf dist
 rm -f node_modules/typescript/tsbuildinfo
 # Compile TypeScript for tests, but don't fail on type errors

--- a/worker/index.ts
+++ b/worker/index.ts
@@ -6,6 +6,12 @@ import { analyzeColors } from "./analysers/colors";
 import { analyzeSEO } from "./analysers/seo";
 import { analyzePerformance } from "./analysers/perf";
 
+if (!process.env.DATABASE_URL) {
+  throw new Error(
+    "DATABASE_URL not set. Please configure the Supabase connection string."
+  );
+}
+
 // Task runners mapping
 const runners: Record<string, (url: string) => Promise<any>> = {
   tech: analyzeTech,


### PR DESCRIPTION
## Summary
- enforce `DATABASE_URL` check in server and worker
- verify environment before running tests
- scrub Neon details from docs and lockfile
- document Supabase vars in `.env.example`

```
$ npx tsx worker/index.ts
🚀 Worker started - initializing...
🔗 Initializing worker database connection...
🔗 Database connection string configured for project: test
✅ Database connection established
```

## Testing
- `npm test` *(fails: Cannot find dependency '@vitest/coverage-v8')*

------
https://chatgpt.com/codex/tasks/task_e_688b761ec9cc832b9de8a39424c679b2