### PR TITLE
chore: drop Neon & PG* env vars; standardise on Supabase

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -9,6 +9,14 @@ if (!process.env.DATABASE_URL) {
   );
 }
 
+// Show the resolved database host at startup for easier troubleshooting
+try {
+  const dbHost = new URL(process.env.DATABASE_URL).host;
+  console.log('🔗 Using database host:', dbHost);
+} catch {
+  console.log('🔗 Using database host: unknown');
+}
+
 const app = express();
 const server = createServer(app);
 

--- a/worker/index.ts
+++ b/worker/index.ts
@@ -12,6 +12,14 @@ if (!process.env.DATABASE_URL) {
   );
 }
 
+// Log the Supabase host for visibility at startup
+try {
+  const dbHost = new URL(process.env.DATABASE_URL).host;
+  console.log('🔗 Using database host:', dbHost);
+} catch {
+  console.log('🔗 Using database host: unknown');
+}
+
 // Task runners mapping
 const runners: Record<string, (url: string) => Promise<any>> = {
   tech: analyzeTech,


### PR DESCRIPTION
## Summary
- ensure server and worker show the DATABASE_URL host on startup

## Testing
- `npm test` *(fails: No tests found)*

------
https://chatgpt.com/codex/tasks/task_e_688b7c3407f0832b99be6a0998bd6059