### PR TITLE
chore: add dev proxy for /api

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -23,6 +23,15 @@ export default defineConfig({
       "@assets": path.resolve(import.meta.dirname, "attached_assets"),
     },
   },
+  server: {
+    proxy: {
+      "/api": {
+        target: "http://localhost:5000",
+        changeOrigin: true,
+        secure: false,
+      },
+    },
+  },
   root: path.resolve(import.meta.dirname, "client"),
   build: {
     outDir: path.resolve(import.meta.dirname, "dist/public"),


### PR DESCRIPTION
## Summary
- proxy /api calls in Vite dev server to Express backend on port 5000

## Testing
- `npm test` *(fails: TypeError: Cannot redefine property: Symbol($$jest-matchers-object))*
- `curl -i -X POST http://localhost:5173/api/scans -H 'Content-Type: application/json' -d '{"url":"https://example.com"}'` *(fails: database connection refused)*
- `npm run worker:dev` *(fails: ECONNREFUSED)*

------
https://chatgpt.com/codex/tasks/task_e_688ebdca8be8832bb789eb2b8b49d3cc