### PR TITLE
chore: fix YAML syntax in accessibility workflow

### DIFF
--- a/.github/workflows/accessibility.yml
+++ b/.github/workflows/accessibility.yml
@@ -50,21 +50,15 @@ jobs:
         script: |
           const fs = require('fs');
           const path = 'pa11y-report.html';
-          
+
           if (fs.existsSync(path)) {
             const report = fs.readFileSync(path, 'utf8');
             const issueCount = (report.match(/error/gi) || []).length;
-            
+
             github.rest.issues.createComment({
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              body: `## 🔍 Accessibility Test Results
-              
-Detected ${issueCount} accessibility issues.
-
-📊 **Report:** Download the full pa11y report from the artifacts section.
-
-🛠️ **Action Required:** Review the accessibility issues and fix them before merging.`
+              body: `## 🔍 Accessibility Test Results\n\nDetected ${issueCount} accessibility issues.\n\n📊 **Report:** Download the full pa11y report from the artifacts section.\n\n🛠️ **Action Required:** Review the accessibility issues and fix them before merging.`
             });
           }


### PR DESCRIPTION
## Summary
- fix indentation and quoting in accessibility GitHub Actions workflow

## Testing
- `yamllint -d '{rules: {document-start: disable, line-length: disable, trailing-spaces: disable, indentation: disable, truthy: disable, brackets: disable}}' .github/workflows/accessibility.yml && echo "YAML OK"`

------
https://chatgpt.com/codex/tasks/task_e_6890110fbf50832b9fc64e95cc1b961b