### PR TITLE
fix: auto-enqueue tasks using DB defaults

### DIFF
--- a/server/routes/scans.ts
+++ b/server/routes/scans.ts
@@ -2,6 +2,10 @@ import { Router } from "express";
 import { sql } from "../db.js";
 import { normalizeUrl } from "../../shared/utils/normalizeUrl.js";
 
+if (!process.env.DATABASE_URL) {
+  throw new Error("DATABASE_URL not set");
+}
+
 const router = Router();
 
 router.post("/api/scans", async (req, res) => {
@@ -17,15 +21,14 @@ router.post("/api/scans", async (req, res) => {
   console.log("✅ scan inserted", scan_id);
 
   // 2️⃣ queue four tasks
-  const taskTypes = ['tech', 'colors', 'seo', 'perf'];
+  const taskTypes = ["tech", "colors", "seo", "perf"];
   const tasks = taskTypes.map((type) => ({
     scan_id,
     type,
-    status: 'queued',
-    created_at: new Date(),
+    status: "queued",
   }));
   await sql`insert into public.scan_tasks ${sql(tasks)}`;
-  console.log(`🆕 tasks queued ${tasks.length} for scan`, scan_id);
+  console.log(`🆕 queued ${tasks.length} tasks for scan`, scan_id);
 
   res.status(201).json({ scan_id });
 });


### PR DESCRIPTION
## Summary
- Guard scan route against missing database config
- Bulk insert four scan_tasks using Postgres default timestamps
- Log queued task count for visibility after scan insertion

## Testing
- `npm test` *(fails: MISSING DEPENDENCY  Cannot find dependency '@vitest/coverage-v8')*

------
https://chatgpt.com/codex/tasks/task_e_689164836e18832b8d3b17f52aeee7b8