### PR TITLE
fix: audit and repair scan queue flow

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -30,7 +30,8 @@ console.log(`📍 SUPABASE_SERVICE_ROLE_KEY: ${process.env.SUPABASE_SERVICE_ROLE
 
 // API Routes
 console.log('🚀 Registering unified API routes...');
-app.use(scansRouter);
+// Mount scans router under /api/scans
+app.use('/api/scans', scansRouter);
 
 // Health check endpoint
 app.get('/api/health', (req, res) => {

--- a/server/routes/scans.ts
+++ b/server/routes/scans.ts
@@ -8,28 +8,37 @@ if (!process.env.DATABASE_URL) {
 
 const router = Router();
 
-router.post("/api/scans", async (req, res) => {
+router.post("/", async (req, res) => {
   console.log("🔔 /api/scans hit", req.body);
   const { url } = req.body as { url: string };
   const normalized = normalizeUrl(url);
 
-  // 1️⃣ insert scan
-  const [{ id: scan_id }] = await sql/*sql*/`
-    insert into public.scans (url, created_at)
-    values (${normalized}, now())
-    returning id`;
-  console.log("✅ scan inserted", scan_id);
+  let scan_id: string;
+  try {
+    const [{ id }] = await sql/*sql*/`
+      insert into public.scans (url, created_at)
+      values (${normalized}, now())
+      returning id`;
+    scan_id = id;
+    console.log("✅ scan inserted", scan_id);
+  } catch (error) {
+    console.error("❌ scan insert failed", error);
+    return res.status(500).json({ error: "failed to insert scan" });
+  }
 
-  // 2️⃣ queue four tasks
-  const taskTypes = ["tech", "colors", "seo", "perf"];
-  const tasks = taskTypes.map((type) => ({
-    scan_id,
-    type,
-    status: "queued",
-
-  }));
-  await sql`insert into public.scan_tasks ${sql(tasks)}`;
-  console.log(`🆕 queued ${tasks.length} tasks for scan`, scan_id);
+  try {
+    const taskTypes = ["tech", "colors", "seo", "perf"];
+    const tasks = taskTypes.map((type) => ({
+      scan_id,
+      type,
+      status: "queued",
+    }));
+    await sql`insert into public.scan_tasks ${sql(tasks)}`;
+    console.log(`🆕 queued ${tasks.length} tasks for scan`, scan_id);
+  } catch (error) {
+    console.error("❌ task insert failed", error);
+    return res.status(500).json({ error: "failed to queue tasks" });
+  }
 
   res.status(201).json({ scan_id });
 });


### PR DESCRIPTION
## Summary
- mount scans router under `/api/scans`
- handle scan creation and task queuing with detailed logging and error handling

## Testing
- `npm run test:unit` *(fails: AssertionError expected 201 to be 404)*
- `DATABASE_URL=postgres://localhost:5432/db npx tsx server/index.ts & curl -i -X POST http://localhost:5000/api/scans -H "Content-Type: application/json" -d '{"url":"https://example.com"}'`


------
https://chatgpt.com/codex/tasks/task_e_689169d9c884832b93fbb0e9e8ce1136