### PR TITLE
fix: instrument and correct status/task API handlers

### DIFF
--- a/server/routes/scans.ts
+++ b/server/routes/scans.ts
@@ -44,4 +44,55 @@ const handleCreateScan = async (req: any, res: any) => {
 
 router.post('/', handleCreateScan);
 
+router.get('/:scanId/status', async (req: any, res: any) => {
+  const { scanId } = req.params as { scanId: string };
+  console.log('🔔 GET status for', scanId);
+  try {
+    const rows = await sql/*sql*/`
+      select status, progress, started_at, finished_at, error
+      from public.scan_status
+      where scan_id = ${scanId}
+      limit 1`;
+    if (!rows.length) {
+      return res.status(404).json({ error: 'status not found' });
+    }
+    const row = rows[0] as any;
+    res.json({
+      status: row.status,
+      progress: row.progress,
+      startedAt: row.started_at,
+      finishedAt: row.finished_at,
+      error: row.error,
+    });
+  } catch (err) {
+    console.error('❌ status route error:', err);
+    res.status(500).json({ error: 'failed to fetch status' });
+  }
+});
+
+router.get('/:scanId/task/:type', async (req: any, res: any) => {
+  const { scanId, type } = req.params as { scanId: string; type: string };
+  console.log('🔔 GET task', type, 'for', scanId);
+  try {
+    const rows = await sql/*sql*/`
+      select task_id, status, payload, created_at
+      from public.scan_tasks
+      where scan_id = ${scanId} and type = ${type}
+      limit 1`;
+    if (!rows.length) {
+      return res.status(404).json({ error: 'task not found' });
+    }
+    const row = rows[0] as any;
+    res.json({
+      taskId: row.task_id,
+      status: row.status,
+      payload: row.payload,
+      createdAt: row.created_at,
+    });
+  } catch (err) {
+    console.error('❌ task route error:', err);
+    res.status(500).json({ error: 'failed to fetch task' });
+  }
+});
+
 export default router;


### PR DESCRIPTION
## Summary
- add GET /api/scans/:scanId/status endpoint querying public.scan_status with logging and error handling
- add GET /api/scans/:scanId/task/:type endpoint querying public.scan_tasks with logging and error handling

## Testing
- `npm test` (fails: DATABASE_URL not set)
- start server with placeholder `DATABASE_URL` and `curl` status/task endpoints (queries attempted, connection refused)


------
https://chatgpt.com/codex/tasks/task_e_6892cc7b9018832b844907a75c33e07a