### PR TITLE
Hardcode Supabase credentials for testing

### DIFF
--- a/clear-supabase.ts
+++ b/clear-supabase.ts
@@ -2,8 +2,8 @@
 
 import { createClient } from '@supabase/supabase-js';
 
-const supabaseUrl = process.env.VITE_SUPABASE_URL!;
-const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY!;
+const supabaseUrl = 'https://kdkuhrbaftksknfgjcch.supabase.co';
+const serviceRoleKey = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6Imtka3VocmJhZnRrc2tuZmdqY2NoIiwicm9sZSI6InNlcnZpY2Vfcm9sZSIsImlhdCI6MTc1NDY1NTk3MiwiZXhwIjoyMDcwMjMxOTcyfQ.GxgZBq4v6SNusEoW9We2Z2yMJcUt7g-YtwCy8IalErA';
 
 // Use service role to bypass RLS
 const supabase = createClient(supabaseUrl, serviceRoleKey, {

--- a/client/src/hooks/useScanProgress.ts
+++ b/client/src/hooks/useScanProgress.ts
@@ -17,9 +17,8 @@ export function useScanProgress(scanId: string): ProgressData {
     // Skip if no scanId provided
     if (!scanId) return;
 
-    // Check if Supabase is properly configured  
-    const hasSupabaseConfig = import.meta.env.VITE_SUPABASE_ANON_KEY &&
-                             import.meta.env.VITE_SUPABASE_ANON_KEY !== 'placeholder-key';
+    // Supabase is always configured with hard-coded credentials
+    const hasSupabaseConfig = true;
 
     if (!hasSupabaseConfig) {
       console.warn('Supabase not configured for realtime, using polling fallback');

--- a/client/src/lib/supabaseClient.ts
+++ b/client/src/lib/supabaseClient.ts
@@ -1,7 +1,7 @@
 import { createClient } from '@supabase/supabase-js';
 
-// Client-side Supabase configuration using environment variables
-const supabaseUrl = import.meta.env.VITE_SUPABASE_URL;
-const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY || 'placeholder-key';
+// Client-side Supabase configuration using hard-coded credentials
+const supabaseUrl = 'https://kdkuhrbaftksknfgjcch.supabase.co';
+const supabaseAnonKey = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6Imtka3VocmJhZnRrc2tuZmdqY2NoIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTQ2NTU5NzIsImV4cCI6MjA3MDIzMTk3Mn0.IdNH8dTjjyKtbdqiO-cDPo1ecOGaeFRTtiTJkSRZG78';
 
 export const supabase = createClient(supabaseUrl, supabaseAnonKey);

--- a/drizzle.config.ts
+++ b/drizzle.config.ts
@@ -1,10 +1,7 @@
 
 import { defineConfig } from "drizzle-kit";
 
-const connectionString = process.env.DATABASE_URL;
-if (!connectionString) {
-  throw new Error("DATABASE_URL not set");
-}
+const connectionString = 'postgresql://postgres.kdkuhrbaftksknfgjcch:[YOUR-PASSWORD]@aws-0-us-east-1.pooler.supabase.com:6543/postgres';
 
 export default defineConfig({
   out: "./migrations",

--- a/server/db.ts
+++ b/server/db.ts
@@ -2,17 +2,15 @@ import { drizzle } from 'drizzle-orm/postgres-js';
 import postgres from 'postgres';
 import * as schema from '../shared/schema.js';
 
-if (!process.env.DATABASE_URL) {
-  throw new Error('DATABASE_URL not set');
-}
+const DATABASE_URL = 'postgresql://postgres.kdkuhrbaftksknfgjcch:[YOUR-PASSWORD]@aws-0-us-east-1.pooler.supabase.com:6543/postgres';
 
 let dbHost = 'unknown';
 try {
-  dbHost = new URL(process.env.DATABASE_URL).host;
+  dbHost = new URL(DATABASE_URL).host;
 } catch {}
 console.log('🔗 Database connection string configured for host:', dbHost);
 
-const connectionString = process.env.DATABASE_URL!;
+const connectionString = DATABASE_URL;
 
 export const sql = postgres(connectionString, {
   max: 10,

--- a/server/index.ts
+++ b/server/index.ts
@@ -5,11 +5,12 @@ import cors from "cors";
 import { sql } from "./db.js";
 import scansRouter from "./routes/scans.js";
 
-const dbUrl = process.env.DATABASE_URL;
-if (!dbUrl) {
-  throw new Error("DATABASE_URL missing");
-}
-console.log('DB_URL', process.env.DATABASE_URL);
+const DATABASE_URL = 'postgresql://postgres.kdkuhrbaftksknfgjcch:[YOUR-PASSWORD]@aws-0-us-east-1.pooler.supabase.com:6543/postgres';
+const VITE_SUPABASE_URL = 'https://kdkuhrbaftksknfgjcch.supabase.co';
+const SUPABASE_SERVICE_ROLE_KEY = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6Imtka3VocmJhZnRrc2tuZmdqY2NoIiwicm9sZSI6InNlcnZpY2Vfcm9sZSIsImlhdCI6MTc1NDY1NTk3MiwiZXhwIjoyMDcwMjMxOTcyfQ.GxgZBq4v6SNusEoW9We2Z2yMJcUt7g-YtwCy8IalErA';
+
+const dbUrl = DATABASE_URL;
+console.log('DB_URL', DATABASE_URL);
 console.log('🔗 Using DATABASE_URL =', dbUrl);
 
 const app = express();
@@ -22,8 +23,8 @@ app.use(express.urlencoded({ extended: true }));
 
 // Supabase configuration check
 console.log('🔧 Supabase configuration check:');
-console.log(`📍 VITE_SUPABASE_URL: ${process.env.VITE_SUPABASE_URL?.substring(0, 50)}...`);
-console.log(`📍 SUPABASE_SERVICE_ROLE_KEY: ${process.env.SUPABASE_SERVICE_ROLE_KEY?.substring(0, 50)}...`);
+console.log(`📍 VITE_SUPABASE_URL: ${VITE_SUPABASE_URL.substring(0, 50)}...`);
+console.log(`📍 SUPABASE_SERVICE_ROLE_KEY: ${SUPABASE_SERVICE_ROLE_KEY.substring(0, 50)}...`);
 
 // API Routes
 console.log('🚀 Registering unified API routes...');

--- a/server/middleware/auth.ts
+++ b/server/middleware/auth.ts
@@ -1,9 +1,12 @@
 import { FastifyRequest, FastifyReply } from 'fastify';
 import { createClient } from '@supabase/supabase-js';
 
+const SUPABASE_URL = 'https://kdkuhrbaftksknfgjcch.supabase.co';
+const SUPABASE_SERVICE_ROLE_KEY = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6Imtka3VocmJhZnRrc2tuZmdqY2NoIiwicm9sZSI6InNlcnZpY2Vfcm9sZSIsImlhdCI6MTc1NDY1NTk3MiwiZXhwIjoyMDcwMjMxOTcyfQ.GxgZBq4v6SNusEoW9We2Z2yMJcUt7g-YtwCy8IalErA';
+
 const supabaseAdmin = createClient(
-  process.env.VITE_SUPABASE_URL!,
-  process.env.SUPABASE_SERVICE_ROLE_KEY!
+  SUPABASE_URL,
+  SUPABASE_SERVICE_ROLE_KEY,
 );
 
 declare module 'fastify' {
@@ -18,16 +21,16 @@ declare module 'fastify' {
 
 export async function authMiddleware(request: FastifyRequest, reply: FastifyReply) {
   const authHeader = request.headers.authorization;
-  
+
   if (!authHeader || !authHeader.startsWith('Bearer ')) {
     return reply.code(401).send({ error: 'Missing or invalid authorization header' });
   }
 
   const token = authHeader.replace('Bearer ', '');
-  
+
   try {
     const { data, error } = await supabaseAdmin.auth.getUser(token);
-    
+
     if (error || !data.user) {
       console.error('Auth error:', error);
       return reply.code(401).send({ error: 'Invalid token' });
@@ -39,7 +42,7 @@ export async function authMiddleware(request: FastifyRequest, reply: FastifyRepl
       email: data.user.email,
       ...data.user,
     };
-    
+
   } catch (error) {
     console.error('Auth middleware error:', error);
     return reply.code(401).send({ error: 'Authentication failed' });
@@ -49,17 +52,17 @@ export async function authMiddleware(request: FastifyRequest, reply: FastifyRepl
 // Optional middleware - doesn't fail if no auth provided
 export async function optionalAuthMiddleware(request: FastifyRequest, reply: FastifyReply) {
   const authHeader = request.headers.authorization;
-  
+
   if (!authHeader || !authHeader.startsWith('Bearer ')) {
     // No auth provided, continue without user
     return;
   }
 
   const token = authHeader.replace('Bearer ', '');
-  
+
   try {
     const { data, error } = await supabaseAdmin.auth.getUser(token);
-    
+
     if (!error && data.user) {
       request.user = {
         id: data.user.id,
@@ -72,3 +75,4 @@ export async function optionalAuthMiddleware(request: FastifyRequest, reply: Fas
     console.warn('Optional auth failed:', error);
   }
 }
+

--- a/server/routes/scans.ts
+++ b/server/routes/scans.ts
@@ -2,10 +2,6 @@ import { Router } from "express";
 import { sql } from "../db.js";
 import { normalizeUrl } from "../../shared/utils/normalizeUrl.js";
 
-if (!process.env.DATABASE_URL) {
-  throw new Error("DATABASE_URL not set");
-}
-
 const router = Router();
 
 const handleCreateScan = async (req: any, res: any) => {

--- a/start-complete-app.sh
+++ b/start-complete-app.sh
@@ -5,6 +5,7 @@
 
 echo "🚀 Starting Website Analysis Tool - Complete Setup"
 
+DATABASE_URL="postgresql://postgres.kdkuhrbaftksknfgjcch:[YOUR-PASSWORD]@aws-0-us-east-1.pooler.supabase.com:6543/postgres"
 echo "🔗 Using $DATABASE_URL"
 
 # Start both server and worker concurrently

--- a/start-server-only.sh
+++ b/start-server-only.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 
+DATABASE_URL="postgresql://postgres.kdkuhrbaftksknfgjcch:[YOUR-PASSWORD]@aws-0-us-east-1.pooler.supabase.com:6543/postgres"
 echo "🔗 Using $DATABASE_URL"
 echo "🚀 Starting server only (without worker)..."
 

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -1,9 +1,6 @@
 #!/bin/bash
 set -e
-if [ -z "$DATABASE_URL" ]; then
-  echo "DATABASE_URL not set. Please configure the Supabase connection string."
-  exit 1
-fi
+DATABASE_URL="postgresql://postgres.kdkuhrbaftksknfgjcch:[YOUR-PASSWORD]@aws-0-us-east-1.pooler.supabase.com:6543/postgres"
 rm -rf dist
 rm -f node_modules/typescript/tsbuildinfo
 # Compile TypeScript for tests, but don't fail on type errors

--- a/tests/unit/useScanProgress.test.tsx
+++ b/tests/unit/useScanProgress.test.tsx
@@ -30,7 +30,6 @@ vi.mock('../../client/src/hooks/useScanStatus', () => ({
 
 describe('useScanProgress', () => {
   let queryClient: QueryClient;
-  const originalEnv = { ...import.meta.env };
 
   const wrapper = ({ children }: { children: ReactNode }) => (
     <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
@@ -44,11 +43,6 @@ describe('useScanProgress', () => {
       },
     });
     vi.clearAllMocks();
-    import.meta.env = { ...originalEnv, VITE_SUPABASE_ANON_KEY: 'key', VITE_SUPABASE_URL: 'url' };
-  });
-
-  afterEach(() => {
-    import.meta.env = originalEnv;
   });
 
   it('should return initial progress from polling fallback', () => {
@@ -84,18 +78,4 @@ describe('useScanProgress', () => {
     });
   });
 
-  it('should handle Supabase configuration errors', () => {
-    // Mock environment variables as undefined
-    const originalEnv = import.meta.env;
-    import.meta.env = { ...originalEnv, VITE_SUPABASE_URL: undefined };
-    
-    const { result } = renderHook(() => useScanProgress('test-scan'), { wrapper });
-    
-    // Should fall back to polling data
-    expect(result.current.progress).toBe(50);
-    expect(result.current.status).toBe('running');
-    
-    // Restore original env
-    import.meta.env = originalEnv;
-  });
 });

--- a/worker/index.ts
+++ b/worker/index.ts
@@ -6,11 +6,12 @@ import { analyzeColors } from "./analysers/colors";
 import { analyzeSEO } from "./analysers/seo";
 import { analyzePerformance } from "./analysers/perf";
 
-const dbUrl = process.env.DATABASE_URL;
-if (!dbUrl) {
-  throw new Error("DATABASE_URL missing");
-}
-console.log('DB_URL', process.env.DATABASE_URL);
+const DATABASE_URL = 'postgresql://postgres.kdkuhrbaftksknfgjcch:[YOUR-PASSWORD]@aws-0-us-east-1.pooler.supabase.com:6543/postgres';
+const SUPABASE_URL = 'https://kdkuhrbaftksknfgjcch.supabase.co';
+const SUPABASE_SERVICE_KEY = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6Imtka3VocmJhZnRrc2tuZmdqY2NoIiwicm9sZSI6InNlcnZpY2Vfcm9sZSIsImlhdCI6MTc1NDY1NTk3MiwiZXhwIjoyMDcwMjMxOTcyfQ.GxgZBq4v6SNusEoW9We2Z2yMJcUt7g-YtwCy8IalErA';
+
+const dbUrl = DATABASE_URL;
+console.log('DB_URL', DATABASE_URL);
 console.log('🔗 Using DATABASE_URL =', dbUrl);
 
 // Task runners mapping
@@ -24,16 +25,10 @@ const runners: Record<string, (url: string, scanId: string) => Promise<any>> = {
 async function initializeWorker() {
   console.log('🔗 Initializing worker database connection...');
 
-  // Load environment variables from process.env
-  const SUPABASE_URL = process.env.VITE_SUPABASE_URL;
-  const SUPABASE_SERVICE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY;
-
-  if (!SUPABASE_URL || !SUPABASE_SERVICE_KEY) {
-    console.error('❌ Missing required environment variables');
-    console.log('VITE_SUPABASE_URL:', SUPABASE_URL ? 'SET' : 'MISSING');
-    console.log('SUPABASE_SERVICE_ROLE_KEY:', SUPABASE_SERVICE_KEY ? 'SET' : 'MISSING');
-    throw new Error('Missing required environment variables');
-  }
+  const SUPABASE_URL_CONST = SUPABASE_URL;
+  const SUPABASE_SERVICE_KEY_CONST = SUPABASE_SERVICE_KEY;
+  console.log('VITE_SUPABASE_URL:', SUPABASE_URL_CONST ? 'SET' : 'MISSING');
+  console.log('SUPABASE_SERVICE_ROLE_KEY:', SUPABASE_SERVICE_KEY_CONST ? 'SET' : 'MISSING');
 
   try {
     // Import database connection with correct extension


### PR DESCRIPTION
## Summary
- hardcode Supabase database URL and keys across server, worker, and scripts
- switch client Supabase setup and hooks to fixed URLs and anon key
- update tests and tooling to reflect removal of env-based configuration

## Testing
- `npm test` *(fails: expected 404 to be 201)*

------
https://chatgpt.com/codex/tasks/task_e_6895f49d8de4832b983d02565a8c038a