### PR TITLE
fix: align migrations with schema

### DIFF
--- a/migrations/20250729_add_scan_tasks.sql
+++ b/migrations/20250729_add_scan_tasks.sql
@@ -1,9 +1,0 @@
-CREATE TABLE IF NOT EXISTS public.scan_tasks (
-  task_id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
-  scan_id UUID NOT NULL REFERENCES public.scans(id) ON DELETE CASCADE,
-  type TEXT NOT NULL,
-  status TEXT NOT NULL DEFAULT 'queued',
-  payload JSONB,
-  created_at timestamptz NOT NULL DEFAULT now()
-);
-CREATE INDEX IF NOT EXISTS scan_tasks_scan_type_idx ON public.scan_tasks(scan_id, type);

--- a/migrations/20250730_add_finished_at.sql
+++ b/migrations/20250730_add_finished_at.sql
@@ -1,2 +1,0 @@
-ALTER TABLE IF NOT EXISTS public.scan_status
-  ADD COLUMN IF NOT EXISTS finished_at timestamp;

--- a/migrations/20250731_update_scan_status.sql
+++ b/migrations/20250731_update_scan_status.sql
@@ -1,0 +1,6 @@
+ALTER TABLE "scan_status" DROP CONSTRAINT scan_status_pkey;
+ALTER TABLE "scan_status" ADD COLUMN "id" uuid DEFAULT gen_random_uuid() NOT NULL;
+ALTER TABLE "scan_status" ADD COLUMN "created_at" timestamp DEFAULT now();
+ALTER TABLE "scan_status" ADD COLUMN "updated_at" timestamp DEFAULT now();
+ALTER TABLE "scan_status" ADD PRIMARY KEY ("id");
+

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "start": "vite preview",
     "worker:dev": "tsx watch worker/index.ts",
     "migrate:supabase": "npx drizzle-kit push:pg --schema \"postgres\".\"public\"",
+    "generate:migration": "npx drizzle-kit generate:pg",
     "check": "tsc",
     "deps:docs": "npx dep-table --out docs/DEPENDENCIES.md",
     "test:unit": "vitest run --coverage",


### PR DESCRIPTION
## Summary
- add generate:migration script to package.json
- drop redundant migration files and add migration aligning scan_status table with code schema

## Testing
- `DATABASE_URL=postgres://postgres:postgres@localhost:5432/postgres npm test` *(fails: expected 201 to be 404)*

------
https://chatgpt.com/codex/tasks/task_e_6895f4c364f8832bb654f7bc7d5eafe6