### PR TITLE
Replace placeholder database password with temporary credential

### DIFF
--- a/drizzle.config.ts
+++ b/drizzle.config.ts
@@ -1,7 +1,7 @@
 
 import { defineConfig } from "drizzle-kit";
 
-const connectionString = 'postgresql://postgres.kdkuhrbaftksknfgjcch:[YOUR-PASSWORD]@aws-0-us-east-1.pooler.supabase.com:6543/postgres';
+const connectionString = 'postgresql://postgres.kdkuhrbaftksknfgjcch:lkFvjLVOXgPXWJ2S@aws-0-us-east-1.pooler.supabase.com:6543/postgres';
 
 export default defineConfig({
   out: "./migrations",

--- a/server/db.ts
+++ b/server/db.ts
@@ -2,7 +2,7 @@ import { drizzle } from 'drizzle-orm/postgres-js';
 import postgres from 'postgres';
 import * as schema from '../shared/schema.js';
 
-const DATABASE_URL = 'postgresql://postgres.kdkuhrbaftksknfgjcch:[YOUR-PASSWORD]@aws-0-us-east-1.pooler.supabase.com:6543/postgres';
+const DATABASE_URL = 'postgresql://postgres.kdkuhrbaftksknfgjcch:lkFvjLVOXgPXWJ2S@aws-0-us-east-1.pooler.supabase.com:6543/postgres';
 
 let dbHost = 'unknown';
 try {

--- a/server/index.ts
+++ b/server/index.ts
@@ -5,7 +5,7 @@ import cors from "cors";
 import { sql } from "./db.js";
 import scansRouter from "./routes/scans.js";
 
-const DATABASE_URL = 'postgresql://postgres.kdkuhrbaftksknfgjcch:[YOUR-PASSWORD]@aws-0-us-east-1.pooler.supabase.com:6543/postgres';
+const DATABASE_URL = 'postgresql://postgres.kdkuhrbaftksknfgjcch:lkFvjLVOXgPXWJ2S@aws-0-us-east-1.pooler.supabase.com:6543/postgres';
 const VITE_SUPABASE_URL = 'https://kdkuhrbaftksknfgjcch.supabase.co';
 const SUPABASE_SERVICE_ROLE_KEY = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6Imtka3VocmJhZnRrc2tuZmdqY2NoIiwicm9sZSI6InNlcnZpY2Vfcm9sZSIsImlhdCI6MTc1NDY1NTk3MiwiZXhwIjoyMDcwMjMxOTcyfQ.GxgZBq4v6SNusEoW9We2Z2yMJcUt7g-YtwCy8IalErA';
 

--- a/start-complete-app.sh
+++ b/start-complete-app.sh
@@ -5,7 +5,7 @@
 
 echo "🚀 Starting Website Analysis Tool - Complete Setup"
 
-DATABASE_URL="postgresql://postgres.kdkuhrbaftksknfgjcch:[YOUR-PASSWORD]@aws-0-us-east-1.pooler.supabase.com:6543/postgres"
+DATABASE_URL="postgresql://postgres.kdkuhrbaftksknfgjcch:lkFvjLVOXgPXWJ2S@aws-0-us-east-1.pooler.supabase.com:6543/postgres"
 echo "🔗 Using $DATABASE_URL"
 
 # Start both server and worker concurrently

--- a/start-server-only.sh
+++ b/start-server-only.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-DATABASE_URL="postgresql://postgres.kdkuhrbaftksknfgjcch:[YOUR-PASSWORD]@aws-0-us-east-1.pooler.supabase.com:6543/postgres"
+DATABASE_URL="postgresql://postgres.kdkuhrbaftksknfgjcch:lkFvjLVOXgPXWJ2S@aws-0-us-east-1.pooler.supabase.com:6543/postgres"
 echo "🔗 Using $DATABASE_URL"
 echo "🚀 Starting server only (without worker)..."
 

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 set -e
-DATABASE_URL="postgresql://postgres.kdkuhrbaftksknfgjcch:[YOUR-PASSWORD]@aws-0-us-east-1.pooler.supabase.com:6543/postgres"
+DATABASE_URL="postgresql://postgres.kdkuhrbaftksknfgjcch:lkFvjLVOXgPXWJ2S@aws-0-us-east-1.pooler.supabase.com:6543/postgres"
 rm -rf dist
 rm -f node_modules/typescript/tsbuildinfo
 # Compile TypeScript for tests, but don't fail on type errors

--- a/worker/index.ts
+++ b/worker/index.ts
@@ -6,7 +6,7 @@ import { analyzeColors } from "./analysers/colors";
 import { analyzeSEO } from "./analysers/seo";
 import { analyzePerformance } from "./analysers/perf";
 
-const DATABASE_URL = 'postgresql://postgres.kdkuhrbaftksknfgjcch:[YOUR-PASSWORD]@aws-0-us-east-1.pooler.supabase.com:6543/postgres';
+const DATABASE_URL = 'postgresql://postgres.kdkuhrbaftksknfgjcch:lkFvjLVOXgPXWJ2S@aws-0-us-east-1.pooler.supabase.com:6543/postgres';
 const SUPABASE_URL = 'https://kdkuhrbaftksknfgjcch.supabase.co';
 const SUPABASE_SERVICE_KEY = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6Imtka3VocmJhZnRrc2tuZmdqY2NoIiwicm9sZSI6InNlcnZpY2Vfcm9sZSIsImlhdCI6MTc1NDY1NTk3MiwiZXhwIjoyMDcwMjMxOTcyfQ.GxgZBq4v6SNusEoW9We2Z2yMJcUt7g-YtwCy8IalErA';
 


### PR DESCRIPTION
## Summary
- replace `[YOUR-PASSWORD]` placeholder with `lkFvjLVOXgPXWJ2S` across configuration files and scripts

## Testing
- `npm test` *(fails: expected 404 to be 201)*

------
https://chatgpt.com/codex/tasks/task_e_689604200ff8832ba7788076b38725c2