### PR TITLE
docs: update migration docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,18 +151,15 @@ npm test
 
 ## Database Management
 
-### Clear Database
-To reset all tables during development:
+### Verification
 
 ```bash
+npm run migrate:supabase
+npm run generate:migration
 npx tsx clear-supabase.ts
-```
-
-### Verify Database Structure
-Check that all required tables exist:
-
-```bash
-psql $DATABASE_URL -c "SELECT table_name FROM information_schema.tables WHERE table_schema = 'public' AND table_name IN ('scans','scan_status','analysis_cache','scan_tasks','users');"
+psql "$DATABASE_URL" -c \
+  "SELECT table_name FROM information_schema.tables \
+   WHERE table_schema='public' AND table_name IN ('scans','scan_status','analysis_cache','scan_tasks','users');"
 ```
 
 ### Monitor Database
@@ -171,3 +168,5 @@ View current scan records:
 ```bash
 psql $DATABASE_URL -c "SELECT COUNT(*) FROM scans;"
 psql $DATABASE_URL -c "SELECT COUNT(*) FROM analysis_cache;"
+```
+

--- a/docs/SUPABASE_SCHEMA.md
+++ b/docs/SUPABASE_SCHEMA.md
@@ -62,8 +62,13 @@ The database also contains these tables:
 - JSONB is used for storing complex analysis results in `analysis_cache`
 - Boolean fields use PostgreSQL's native boolean type
 
-## Clearing Database
-Use the provided `clear-supabase.ts` script to safely clear all tables:
+## Verification
+
 ```bash
+npm run migrate:supabase
+npm run generate:migration
 npx tsx clear-supabase.ts
+psql "$DATABASE_URL" -c \
+  "SELECT table_name FROM information_schema.tables \
+   WHERE table_schema='public' AND table_name IN ('scans','scan_status','analysis_cache','scan_tasks','users');"
 ```


### PR DESCRIPTION
## Summary
- document using `npm run migrate:supabase` for database migrations
- add verification workflow including `clear-supabase.ts` and schema check

## Testing
- `npm test` *(fails: expected 404 to be 201)*

------
https://chatgpt.com/codex/tasks/task_e_689608632ecc832bad03d97dbe97a139