### PR TITLE
chore: update drizzle migration command

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "build": "vite build",
     "start": "vite preview",
     "worker:dev": "tsx watch worker/index.ts",
-    "migrate:supabase": "npx drizzle-kit push:pg",
+    "migrate:supabase": "npx drizzle-kit push",
     "generate:migration": "npx drizzle-kit generate:pg --config drizzle.config.ts",
     "check": "tsc",
     "deps:docs": "npx dep-table --out docs/DEPENDENCIES.md",


### PR DESCRIPTION
## Summary
- replace deprecated `push:pg` with new `push` in migrate:supabase script

## Testing
- `npm run migrate:supabase` *(fails: connect ENETUNREACH 52.45.94.125:6543 - Local (0.0.0.0:0))*

------
https://chatgpt.com/codex/tasks/task_e_68960bf0e93c832bbc6d634aa20d4b8c