### PR TITLE
Use transaction for scan task inserts

### DIFF
--- a/server/routes/scans.ts
+++ b/server/routes/scans.ts
@@ -29,8 +29,16 @@ const handleCreateScan = async (req: any, res: any) => {
       status: 'queued',
       created_at: new Date().toISOString(),
     }));
-    await sql/*sql*/`insert into public.scan_tasks ${sql(tasks)}`;
-    console.log('🆕 tasks queued 4 for scan', scan_id);
+
+    const transaction = await sql.begin();
+    try {
+      await transaction/*sql*/`insert into public.scan_tasks (scan_id, type, status, created_at) values ${sql(tasks, 'scan_id','type','status','created_at')}`;
+      await transaction.commit();
+      console.log('🆕 tasks queued 4 for scan', scan_id);
+    } catch (taskErr) {
+      await transaction.rollback();
+      throw taskErr;
+    }
 
     res.status(201).json({ scan_id });
   } catch (err) {


### PR DESCRIPTION
## Summary
- wrap scan task creation in a SQL transaction
- insert scan tasks with explicit column list and commit or rollback

## Testing
- `npm test` *(fails: POST /api/scans > creates scan and queues four tasks)*

------
https://chatgpt.com/codex/tasks/task_e_689699b8d18c832bb8b4e33a15529650