### PR TITLE
feat: add simple analysis path

### DIFF
--- a/migrations/20250909_add_scan_results.sql
+++ b/migrations/20250909_add_scan_results.sql
@@ -1,0 +1,10 @@
+CREATE TABLE IF NOT EXISTS "scan_results" (
+  "id" uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  "url" text NOT NULL,
+  "requested_at" timestamptz NOT NULL DEFAULT now(),
+  "duration_ms" integer NOT NULL,
+  "status" text NOT NULL CHECK (status IN ('ok','error')),
+  "error" text,
+  "results" jsonb NOT NULL
+);
+CREATE INDEX IF NOT EXISTS "scan_results_url_idx" ON "scan_results" ("url");

--- a/server/index.ts
+++ b/server/index.ts
@@ -4,6 +4,7 @@ import { setupVite, serveStatic, log } from "./vite";
 import cors from "cors";
 import { sql } from "./db.js";
 import scansRouter from "./routes/scans.js";
+import overviewRouter from "./routes/overview.js";
 
 const DATABASE_URL = 'postgresql://postgres.kdkuhrbaftksknfgjcch:lkFvjLVOXgPXWJ2S@aws-0-us-east-1.pooler.supabase.com:6543/postgres';
 const VITE_SUPABASE_URL = 'https://kdkuhrbaftksknfgjcch.supabase.co';
@@ -28,7 +29,16 @@ console.log(`📍 SUPABASE_SERVICE_ROLE_KEY: ${SUPABASE_SERVICE_ROLE_KEY.substri
 
 // API Routes
 console.log('🚀 Registering unified API routes...');
-// Mount scans router directly (it defines its own /api/scans paths)
+const ANALYSIS_MODE = process.env.ANALYSIS_MODE || 'simple';
+console.log('🧪 ANALYSIS_MODE =', ANALYSIS_MODE);
+
+// Mount overview router only in simple mode
+if (ANALYSIS_MODE === 'simple') {
+  console.log('✅ Simple analysis mode enabled. Use /api/overview for synchronous analysis.');
+  app.use(overviewRouter);
+}
+
+// Mount scans router (queued path)
 app.use(scansRouter);
 
 // Health check endpoint

--- a/server/lib/axe-integration.ts
+++ b/server/lib/axe-integration.ts
@@ -133,8 +133,6 @@ export async function getAccessibilityAnalysis(page: Page, url: string): Promise
     const cacheKey = `axe_accessibility_${urlHash}`;
 
     // Try cache first
-    }
-
     console.log('🔍 Performing fresh axe accessibility analysis...');
     const analysis = await runAxeAnalysis(page, url);
 

--- a/server/routes/overview.ts
+++ b/server/routes/overview.ts
@@ -1,0 +1,124 @@
+import { Router } from 'express';
+import { normalizeUrl } from '../../shared/utils/normalizeUrl.js';
+import { db } from '../db.js';
+import { scanResults } from '../../shared/schema.js';
+import { getLighthousePerformance } from '../lib/lighthouse-service.js';
+import { extractSEOData } from '../lib/seo-extractor.js';
+import { extractColors } from '../lib/color-extraction.js';
+import { runAxeAnalysis } from '../lib/axe-integration.js';
+import { getTechnicalAnalysis } from '../lib/tech-lightweight.js';
+import { chromium } from 'playwright';
+
+const router = Router();
+
+async function performAnalysis(url: string) {
+  const start = Date.now();
+  const results: any = { data: {} };
+
+  try {
+    const performance = await getLighthousePerformance(url);
+    const seo = await extractSEOData(url);
+    const colors = await extractColors(url);
+    const tech = await getTechnicalAnalysis(url);
+
+    let accessibility: any = { contrastIssues: [], violations: [], score: 0 };
+    try {
+      const browser = await chromium.launch({
+        headless: true,
+        args: ['--no-sandbox', '--disable-setuid-sandbox', '--disable-dev-shm-usage']
+      });
+      const page = await browser.newPage();
+      await page.goto(url, { waitUntil: 'load', timeout: 30000 });
+      accessibility = await runAxeAnalysis(page, url);
+      await browser.close();
+    } catch (err) {
+      console.error('Accessibility analysis failed:', err);
+    }
+
+    results.data = {
+      overview: {
+        overallScore: performance.score,
+        seoScore: seo.score,
+        userExperienceScore: accessibility.score,
+        colors: colors.map(c => c.hex),
+        contrastIssues: accessibility.contrastIssues,
+      },
+      performance: {
+        performanceScore: performance.score,
+        coreWebVitals: {
+          lcpMs: performance.metrics.largestContentfulPaint?.numericValue || 0,
+          inpMs: performance.metrics.interactionToNextPaint?.numericValue || 0,
+          cls: performance.metrics.cumulativeLayoutShift?.numericValue || 0,
+        },
+        pageLoadTime: performance.pageLoadTime,
+      },
+      seo,
+      ui: {
+        colors,
+        contrastIssues: accessibility.contrastIssues,
+      },
+      technical: {
+        accessibility: {
+          violations: accessibility.violations?.map((v: any) => ({ id: v.id, description: v.description })) || [],
+        },
+      },
+      tech,
+    };
+
+    const duration = Date.now() - start;
+    return { duration, results };
+  } catch (error) {
+    const duration = Date.now() - start;
+    throw { error, duration, results };
+  }
+}
+
+async function handleAnalysis(url: string) {
+  const normalizedUrl = normalizeUrl(url);
+  let status: 'ok' | 'error' = 'ok';
+  let errorMsg: string | null = null;
+  let analysisResults: any = {};
+  let duration = 0;
+
+  try {
+    const { duration: d, results } = await performAnalysis(normalizedUrl);
+    duration = d;
+    analysisResults = results;
+  } catch (err: any) {
+    status = 'error';
+    duration = err.duration || 0;
+    analysisResults = err.results || {};
+    errorMsg = err.error ? (err.error.message || String(err.error)) : 'analysis failed';
+  }
+
+  const [row] = await db.insert(scanResults).values({
+    url: normalizedUrl,
+    durationMs: duration,
+    status,
+    error: errorMsg,
+    results: analysisResults,
+  }).returning({ id: scanResults.id });
+
+  return { id: row.id, url: normalizedUrl, status, duration_ms: duration, error: errorMsg, results: analysisResults };
+}
+
+router.get('/api/overview', async (req, res) => {
+  const url = typeof req.query.url === 'string' ? req.query.url : undefined;
+  if (!url) {
+    return res.status(400).json({ error: 'URL parameter is required' });
+  }
+  const response = await handleAnalysis(url);
+  res.status(response.status === 'ok' ? 200 : 500).json(response);
+});
+
+router.post('/api/overview', async (req, res) => {
+  const { url } = req.body || {};
+  if (!url || typeof url !== 'string') {
+    return res.status(400).json({ error: 'URL is required' });
+  }
+  const response = await handleAnalysis(url);
+  res.status(response.status === 'ok' ? 200 : 500).json(response);
+});
+
+export default router;
+

--- a/server/routes/scans.ts
+++ b/server/routes/scans.ts
@@ -6,6 +6,9 @@ const router = Router();
 
 const handleCreateScan = async (req: any, res: any) => {
   console.log('🔔 /api/scans', req.body);
+  if (process.env.ANALYSIS_MODE !== 'queued') {
+    return res.status(501).json({ error: 'Queued analysis disabled. Use /api/overview or set ANALYSIS_MODE=queued.' });
+  }
   try {
     const { url } = req.body as { url?: string };
     if (!url) {

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -1,4 +1,4 @@
-import { pgTable, text, serial, uuid, timestamp, jsonb, boolean, smallint } from "drizzle-orm/pg-core";
+import { pgTable, text, serial, uuid, timestamp, jsonb, boolean, smallint, integer, index } from "drizzle-orm/pg-core";
 import { createInsertSchema } from "drizzle-zod";
 import { z } from "zod";
 
@@ -68,6 +68,19 @@ export const scanTasks = pgTable("scan_tasks", {
     .defaultNow(),
 });
 
+// scan_results
+export const scanResults = pgTable("scan_results", {
+  id: uuid("id").primaryKey().defaultRandom(),
+  url: text("url").notNull(),
+  requestedAt: timestamp("requested_at", { withTimezone: true }).notNull().defaultNow(),
+  durationMs: integer("duration_ms").notNull(),
+  status: text("status").$type<'ok' | 'error'>().notNull(),
+  error: text("error"),
+  results: jsonb("results").notNull(),
+}, (table) => ({
+  urlIdx: index("scan_results_url_idx").on(table.url),
+}));
+
 export const insertUserSchema = createInsertSchema(users).pick({
   username: true,
   password: true,
@@ -112,3 +125,5 @@ export type InsertAnalysisCache = z.infer<typeof insertAnalysisCacheSchema>;
 export type AnalysisCache = typeof analysisCache.$inferSelect;
 export type InsertScanTasks = z.infer<typeof insertScanTasksSchema>;
 export type ScanTasks = typeof scanTasks.$inferSelect;
+export type ScanResults = typeof scanResults.$inferSelect;
+export type InsertScanResults = typeof scanResults.$inferInsert;


### PR DESCRIPTION
## Summary
- add `scan_results` table for synchronous analysis records
- implement `/api/overview` endpoint performing inline analysis and storing results
- introduce `ANALYSIS_MODE` flag and simple-mode guard for `/api/scans`

## Testing
- `npm run migrate:supabase` *(fails: connect ENETUNREACH)*
- `ANALYSIS_MODE=queued npm test` *(fails: Network error / No tests found)*
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_6896e70c08a8832bba70f2f27e04a393