### PR TITLE
feat: switch to simple analysis flow

### DIFF
--- a/client/src/lib/simpleAdapter.ts
+++ b/client/src/lib/simpleAdapter.ts
@@ -1,0 +1,22 @@
+import type { AnalysisResponse } from '@/types/analysis';
+
+export interface SimpleAnalysisResponse {
+  id: string;
+  url: string;
+  status: 'ok' | 'error';
+  duration_ms: number;
+  error?: string | null;
+  results: {
+    data: any;
+  };
+}
+
+// Convert server's simple analysis response into AnalysisResponse shape
+export function adaptSimpleResponse(res: SimpleAnalysisResponse): AnalysisResponse {
+  return {
+    id: res.id,
+    url: res.url,
+    status: res.status === 'ok' ? 'complete' : 'error',
+    data: res.results?.data || {}
+  } as AnalysisResponse;
+}

--- a/client/src/pages/Dashboard.tsx
+++ b/client/src/pages/Dashboard.tsx
@@ -17,7 +17,7 @@ interface DashboardProps {
 
 const Dashboard = ({ darkMode, toggleDarkMode }: DashboardProps) => {
   const location = useLocation();
-  const { scanId } = useParams<{ scanId: string }>();
+  const { scanId } = useParams<{ scanId?: string }>();
   const { analyzeWebsite, data } = useAnalysisContext();
 
   // Task types for the new local-first architecture

--- a/tests/integration/createScan.test.ts
+++ b/tests/integration/createScan.test.ts
@@ -26,6 +26,7 @@ vi.mock('../../server/db.js', () => ({
 let app: express.Express;
 
 beforeAll(async () => {
+  process.env.ANALYSIS_MODE = 'queued';
   const router = (await import('../../server/routes/scans.ts')).default;
   app = express();
   app.use(express.json());

--- a/tests/unit/urlInputForm.test.tsx
+++ b/tests/unit/urlInputForm.test.tsx
@@ -2,8 +2,11 @@ import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import URLInputForm from '@/components/URLInputForm';
 
+const setAnalysis = vi.fn();
+const setError = vi.fn();
+const setLoading = vi.fn();
 vi.mock('@/contexts/AnalysisContext', () => ({
-  useAnalysisContext: () => ({ analyzeWebsite: vi.fn(), loading: false, error: null })
+  useAnalysisContext: () => ({ setAnalysis, setError, setLoading, loading: false, error: null })
 }));
 vi.mock('react-router-dom', () => ({
   useNavigate: () => vi.fn(),
@@ -14,14 +17,19 @@ describe('URLInputForm', () => {
     vi.clearAllMocks();
   });
 
-  it('posts to /api/scans and logs status', async () => {
+  it('calls /api/overview and stores result in context', async () => {
     const fetchMock = vi.fn().mockResolvedValue({
-      status: 201,
-      json: vi.fn().mockResolvedValue({ id: '1', url: 'https://example.com', created_at: 'now' }),
       ok: true,
+      status: 200,
+      json: vi.fn().mockResolvedValue({
+        id: '1',
+        url: 'https://example.com',
+        status: 'ok',
+        duration_ms: 10,
+        results: { data: {} }
+      }),
     });
     global.fetch = fetchMock as any;
-    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
 
     render(<URLInputForm />);
 
@@ -29,9 +37,9 @@ describe('URLInputForm', () => {
     fireEvent.submit(screen.getByRole('button').closest('form')!);
 
     await waitFor(() => {
-      expect(fetchMock).toHaveBeenCalledWith('/api/scans', expect.objectContaining({ method: 'POST' }));
+      expect(fetchMock).toHaveBeenCalledWith('/api/overview', expect.objectContaining({ method: 'POST' }));
     });
 
-    expect(logSpy).toHaveBeenCalledWith('📥 /api/scans status', 201);
+    expect(setAnalysis).toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary
- wire URL submission to POST /api/overview when VITE_ANALYSIS_MODE!=queued
- keep queued scan path behind VITE_ANALYSIS_MODE flag
- store synchronous analysis payload in context via simpleAdapter
- add tests for new flow and enable queued mode in legacy test

## Testing
- `npm run test:unit`

------
https://chatgpt.com/codex/tasks/task_e_6896ea51af14832b87c904d4c769c592