### PR TITLE
chore: add scan results table migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,3 +170,12 @@ psql $DATABASE_URL -c "SELECT COUNT(*) FROM scans;"
 psql $DATABASE_URL -c "SELECT COUNT(*) FROM analysis_cache;"
 ```
 
+
+### Simple Results Table Migration
+
+```bash
+npm run migrate:supabase
+# verify
+psql "$DATABASE_URL" -c "\d+ public.scan_results"
+psql "$DATABASE_URL" -c "select * from public.scan_results order by requested_at desc limit 1;"
+```

--- a/migrations/20250912_add_scan_results.sql
+++ b/migrations/20250912_add_scan_results.sql
@@ -1,0 +1,11 @@
+CREATE EXTENSION IF NOT EXISTS "pgcrypto";
+CREATE TABLE IF NOT EXISTS "scan_results" (
+  "id" uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  "url" text NOT NULL,
+  "requested_at" timestamptz NOT NULL DEFAULT now(),
+  "duration_ms" integer NOT NULL,
+  "status" text NOT NULL CHECK (status IN ('ok','error')),
+  "error" text,
+  "results" jsonb NOT NULL
+);
+CREATE INDEX IF NOT EXISTS "scan_results_url_idx" ON "scan_results" ("url");


### PR DESCRIPTION
## Summary
- add migration to create scan_results table with uuid id, request timing, status, error, and JSON results
- document manual migration and verification steps

## Testing
- `npm test` *(fails: TypeError Cannot redefine property: Symbol($$jest-matchers-object))*

------
https://chatgpt.com/codex/tasks/task_e_6896ed10d070832ba622531602e04434