### PR TITLE
Use simple analysis flow and normalize color results

### DIFF
--- a/client/src/lib/simpleAdapter.ts
+++ b/client/src/lib/simpleAdapter.ts
@@ -13,10 +13,12 @@ export interface SimpleAnalysisResponse {
 
 // Convert server's simple analysis response into AnalysisResponse shape
 export function adaptSimpleResponse(res: SimpleAnalysisResponse): AnalysisResponse {
+  const data = res.results?.data || {};
+  const merged = { ...data, ...(data.ui || {}) };
   return {
     id: res.id,
     url: res.url,
     status: res.status === 'ok' ? 'complete' : 'error',
-    data: res.results?.data || {}
+    data: merged
   } as AnalysisResponse;
 }

--- a/server/routes/overview.ts
+++ b/server/routes/overview.ts
@@ -5,6 +5,7 @@ import { scanResults } from '../../shared/schema.js';
 import { getLighthousePerformance } from '../lib/lighthouse-service.js';
 import { extractSEOData } from '../lib/seo-extractor.js';
 import { extractColors } from '../lib/color-extraction.js';
+import * as colorHelpers from '../lib/color-extraction.js';
 import { runAxeAnalysis } from '../lib/axe-integration.js';
 import { getTechnicalAnalysis } from '../lib/tech-lightweight.js';
 import { chromium } from 'playwright';
@@ -97,16 +98,22 @@ async function handleAnalysis(url: string) {
     analysisResults?.data?.ui?.colors ??
     analysisResults?.data?.overview?.colors ?? [];
 
+  const toName = (hex: string) => {
+    try {
+      const fn = (colorHelpers as any).getColorName;
+      return typeof fn === 'function' ? fn(hex) : '';
+    } catch {
+      return '';
+    }
+  };
+
   const normalizedColors = (hexes as any[]).map((c: any) => {
     const hex = typeof c === 'string' ? c : c.hex;
     return {
       hex,
-      name: typeof c === 'string' ? '' : c.name || '',
+      name: toName(hex),
       usage: 'palette',
-      count:
-        typeof c === 'string'
-          ? 1
-          : (c.occurrences ?? c.count ?? 1),
+      count: 1,
     };
   });
 

--- a/tests/unit/urlInputForm.test.tsx
+++ b/tests/unit/urlInputForm.test.tsx
@@ -2,14 +2,14 @@ import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import URLInputForm from '@/components/URLInputForm';
 
-const setAnalysis = vi.fn();
-const setError = vi.fn();
-const setLoading = vi.fn();
+const analyzeWebsite = vi.fn().mockResolvedValue({});
+const navigateMock = vi.fn();
+
 vi.mock('@/contexts/AnalysisContext', () => ({
-  useAnalysisContext: () => ({ setAnalysis, setError, setLoading, loading: false, error: null })
+  useAnalysisContext: () => ({ analyzeWebsite, loading: false, error: null })
 }));
 vi.mock('react-router-dom', () => ({
-  useNavigate: () => vi.fn(),
+  useNavigate: () => navigateMock,
 }));
 
 describe('URLInputForm', () => {
@@ -17,29 +17,15 @@ describe('URLInputForm', () => {
     vi.clearAllMocks();
   });
 
-  it('calls /api/overview and stores result in context', async () => {
-    const fetchMock = vi.fn().mockResolvedValue({
-      ok: true,
-      status: 200,
-      json: vi.fn().mockResolvedValue({
-        id: '1',
-        url: 'https://example.com',
-        status: 'ok',
-        duration_ms: 10,
-        results: { data: {} }
-      }),
-    });
-    global.fetch = fetchMock as any;
-
+  it('calls analyzeWebsite and navigates on success', async () => {
     render(<URLInputForm />);
 
     fireEvent.change(screen.getByPlaceholderText(/enter website url/i), { target: { value: 'https://example.com' } });
     fireEvent.submit(screen.getByRole('button').closest('form')!);
 
     await waitFor(() => {
-      expect(fetchMock).toHaveBeenCalledWith('/api/overview', expect.objectContaining({ method: 'POST' }));
+      expect(analyzeWebsite).toHaveBeenCalledWith('https://example.com');
+      expect(navigateMock).toHaveBeenCalledWith('/dashboard');
     });
-
-    expect(setAnalysis).toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary
- ensure overview API stores structured color palette entries
- send URL submissions through overview endpoint and store analysis in context
- flatten simple analysis response so UI tabs can read color data

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68971522b62c832b90e9e632d06550e0